### PR TITLE
Rename ESC tab to Environment

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -55,7 +55,7 @@ impl Tab {
         match self {
             Tab::Dashboard => " Dashboard ",
             Tab::Stacks => " Stacks ",
-            Tab::Esc => " ESC ",
+            Tab::Esc => " Environment ",
             Tab::Neo => " NEO ",
         }
     }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -55,7 +55,7 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
             ],
         ),
         (
-            "ESC View",
+            "Environment View",
             vec![
                 ("Enter", "Load environment definition"),
                 ("o", "Open & resolve environment values"),


### PR DESCRIPTION
## Summary
- Renames the "ESC" tab label to "Environment" for better clarity
- Updates the corresponding help popup section title to match

## Test plan
- [ ] Run `cargo check` to verify compilation
- [ ] Launch the TUI and verify the tab now shows "Environment" instead of "ESC"
- [ ] Open help (?) and verify the section is now titled "Environment View"

🤖 Generated with [Claude Code](https://claude.com/claude-code)