### PR TITLE
Add file-based logging with in-app log viewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,31 @@ cargo check
 RUST_LOG=debug cargo run --release
 ```
 
+## Logging
+
+Logs are written to a file instead of stdout to avoid interfering with the TUI:
+- **Log file location**: `~/.cache/lazy-pulumi/app.log`
+- Press `l` globally to open the log viewer popup
+- Logs are color-coded by level (ERROR=red, WARN=yellow, INFO=blue, DEBUG=muted)
+
+### Log Viewer Key Bindings
+| Key | Action |
+|-----|--------|
+| `l` or `Esc` | Close logs |
+| `w` | Toggle word wrap on/off |
+| `j` / `↓` | Scroll down 3 lines |
+| `k` / `↑` | Scroll up 3 lines |
+| `J` / `PageDown` | Scroll down by page |
+| `K` / `PageUp` | Scroll up by page |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+| `R` | Refresh logs |
+
+### Implementation
+- `src/logging.rs` - File-based logging initialization and log reading
+- `src/ui/logs.rs` - Log viewer popup rendering with word wrap support
+- Logs are cached when viewer opens; press `R` to reload from file
+
 ## Required Environment Variables
 
 ```bash

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,96 @@
+//! File-based logging module
+//!
+//! Redirects tracing output to a file to avoid interfering with the TUI.
+
+use color_eyre::Result;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use tracing_subscriber::prelude::*;
+
+/// Global log file path
+static LOG_FILE_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Get the log file path
+pub fn log_file_path() -> PathBuf {
+    LOG_FILE_PATH
+        .get()
+        .cloned()
+        .unwrap_or_else(|| {
+            directories::BaseDirs::new()
+                .map(|dirs| dirs.cache_dir().join("lazy-pulumi").join("app.log"))
+                .unwrap_or_else(|| PathBuf::from("/tmp/lazy-pulumi.log"))
+        })
+}
+
+/// Initialize file-based logging
+pub fn init_file_logging() -> Result<()> {
+    // Determine log file path
+    let log_path = directories::BaseDirs::new()
+        .map(|dirs| {
+            let cache_dir = dirs.cache_dir().join("lazy-pulumi");
+            std::fs::create_dir_all(&cache_dir).ok();
+            cache_dir.join("app.log")
+        })
+        .unwrap_or_else(|| PathBuf::from("/tmp/lazy-pulumi.log"));
+
+    // Store the path globally
+    let _ = LOG_FILE_PATH.set(log_path.clone());
+
+    // Create/truncate the log file
+    let log_file = File::create(&log_path)?;
+
+    // Set up tracing to write to file
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(log_file)
+        .with_ansi(false)
+        .with_target(false);
+
+    let env_filter = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive(tracing::Level::INFO.into());
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(file_layer)
+        .init();
+
+    tracing::info!("Lazy Pulumi started - logging to {:?}", log_path);
+
+    Ok(())
+}
+
+/// Read the last N lines from the log file
+pub fn read_log_lines(max_lines: usize) -> Vec<String> {
+    let log_path = log_file_path();
+
+    let file = match OpenOptions::new().read(true).open(&log_path) {
+        Ok(f) => f,
+        Err(_) => return vec!["Log file not found".to_string()],
+    };
+
+    let reader = BufReader::new(file);
+    let all_lines: Vec<String> = reader.lines().filter_map(|l| l.ok()).collect();
+
+    // Return last max_lines
+    if all_lines.len() > max_lines {
+        all_lines[all_lines.len() - max_lines..].to_vec()
+    } else {
+        all_lines
+    }
+}
+
+/// Read all lines from the log file with an optional tail
+pub fn read_log_tail(tail_lines: Option<usize>) -> Vec<String> {
+    match tail_lines {
+        Some(n) => read_log_lines(n),
+        None => {
+            let log_path = log_file_path();
+            let file = match OpenOptions::new().read(true).open(&log_path) {
+                Ok(f) => f,
+                Err(_) => return vec!["Log file not found".to_string()],
+            };
+            BufReader::new(file).lines().filter_map(|l| l.ok()).collect()
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod api;
 mod app;
 mod components;
 mod event;
+mod logging;
 mod theme;
 mod tui;
 mod ui;
@@ -19,14 +20,8 @@ async fn main() -> Result<()> {
     // Initialize error handling
     color_eyre::install()?;
 
-    // Initialize tracing for debugging (optional)
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive(tracing::Level::INFO.into()),
-        )
-        .with_target(false)
-        .init();
+    // Initialize tracing to file (so it doesn't interfere with TUI)
+    logging::init_file_logging()?;
 
     // Create and run the application
     let mut app = App::new().await?;

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -30,7 +30,8 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
             "Global",
             vec![
                 ("Tab / Shift+Tab", "Switch between views"),
-                ("O (capital)", "Select organization"),
+                ("o", "Select organization"),
+                ("l", "View application logs"),
                 ("?", "Toggle help"),
                 ("q / Ctrl+C", "Quit application"),
                 ("r", "Refresh data"),

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -1,0 +1,141 @@
+//! Log viewer popup rendering
+
+use ratatui::{
+    prelude::*,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
+
+use crate::theme::Theme;
+use crate::ui::centered_rect;
+
+/// Render the logs popup
+pub fn render_logs(
+    frame: &mut Frame,
+    theme: &Theme,
+    log_lines: &[String],
+    scroll_offset: usize,
+    word_wrap: bool,
+) {
+    let area = centered_rect(90, 85, frame.area());
+
+    // Clear background
+    frame.render_widget(Clear, area);
+
+    let wrap_indicator = if word_wrap { "wrap:ON" } else { "wrap:OFF" };
+    let title = format!(" Logs [w:{}] (l:close, j/k:scroll, g/G:top/bottom, R:refresh) ", wrap_indicator);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border_focused())
+        .title(title)
+        .title_style(theme.title());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_width = inner.width as usize;
+    let visible_height = inner.height as usize;
+
+    // When word wrap is enabled, we need to calculate wrapped line count
+    let (display_lines, total_display_lines) = if word_wrap {
+        // Calculate total wrapped lines and create display content
+        let mut wrapped_lines: Vec<(String, Style)> = Vec::new();
+
+        for line in log_lines.iter() {
+            let style = get_line_style(line, theme);
+
+            if line.is_empty() {
+                wrapped_lines.push((String::new(), style));
+            } else {
+                // Wrap the line manually
+                let chars: Vec<char> = line.chars().collect();
+                let mut start = 0;
+                while start < chars.len() {
+                    let end = (start + visible_width).min(chars.len());
+                    let segment: String = chars[start..end].iter().collect();
+                    wrapped_lines.push((segment, style));
+                    start = end;
+                }
+            }
+        }
+
+        let total = wrapped_lines.len();
+
+        // Clamp scroll offset
+        let max_scroll = total.saturating_sub(visible_height);
+        let scroll = scroll_offset.min(max_scroll);
+
+        // Get visible wrapped lines
+        let visible: Vec<Line> = wrapped_lines
+            .into_iter()
+            .skip(scroll)
+            .take(visible_height)
+            .map(|(text, style)| Line::from(Span::styled(text, style)))
+            .collect();
+
+        (visible, total)
+    } else {
+        // No wrapping - use original lines
+        let total = log_lines.len();
+
+        // Clamp scroll offset
+        let max_scroll = total.saturating_sub(visible_height);
+        let scroll = scroll_offset.min(max_scroll);
+
+        let visible: Vec<Line> = log_lines
+            .iter()
+            .skip(scroll)
+            .take(visible_height)
+            .map(|line| {
+                let style = get_line_style(line, theme);
+                Line::from(Span::styled(line.as_str(), style))
+            })
+            .collect();
+
+        (visible, total)
+    };
+
+    let logs_para = Paragraph::new(display_lines);
+    frame.render_widget(logs_para, inner);
+
+    // Render scrollbar if needed
+    if total_display_lines > visible_height {
+        let scrollbar = Scrollbar::default()
+            .orientation(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("↑"))
+            .end_symbol(Some("↓"));
+
+        // Calculate scroll position for scrollbar
+        let max_scroll = total_display_lines.saturating_sub(visible_height);
+        let scroll = scroll_offset.min(max_scroll);
+
+        let mut scrollbar_state = ScrollbarState::new(total_display_lines)
+            .position(scroll)
+            .viewport_content_length(visible_height);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            inner.inner(Margin {
+                vertical: 1,
+                horizontal: 0,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+/// Get the style for a log line based on its content
+fn get_line_style(line: &str, theme: &Theme) -> Style {
+    if line.contains("ERROR") || line.contains("error") {
+        theme.error()
+    } else if line.contains("WARN") || line.contains("warn") {
+        theme.warning()
+    } else if line.contains("INFO") || line.contains("info") {
+        theme.info()
+    } else if line.contains("DEBUG") || line.contains("debug") {
+        theme.text_muted()
+    } else {
+        theme.text()
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@ mod dashboard;
 mod esc;
 mod header;
 mod help;
+mod logs;
 mod neo;
 mod stacks;
 
@@ -13,6 +14,7 @@ pub use dashboard::render_dashboard;
 pub use esc::render_esc_view;
 pub use header::render_header;
 pub use help::render_help;
+pub use logs::render_logs;
 pub use neo::render_neo_view;
 pub use stacks::render_stacks_view;
 


### PR DESCRIPTION
## Summary
- Redirect tracing output to `~/.cache/lazy-pulumi/app.log` instead of stdout to avoid interfering with TUI
- Add `l` key binding to open log viewer popup from any screen
- Log viewer supports scrolling (j/k/J/K/g/G), word wrap toggle (w), and refresh (R)
- Logs are color-coded by level (ERROR=red, WARN=yellow, INFO=blue, DEBUG=muted)

## Test plan
- [x] Build succeeds with `cargo build --release`
- [ ] Press `l` to open log viewer
- [ ] Test scroll with j/k and page navigation with J/K
- [ ] Toggle word wrap with `w` key
- [ ] Refresh logs with `R` key
- [ ] Close with `l` or `Esc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)