### PR TITLE
Add Neo task details dialog with 'd' key shortcut

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ curl -s -H "Content-Type: application/json" \
 
 The NEO AI agent uses the Preview Agents API:
 - **List tasks**: `GET /api/preview/agents/{org}/tasks`
+- **Get task metadata**: `GET /api/preview/agents/{org}/tasks/{taskId}` - Returns single task details
 - **Create task**: `POST /api/preview/agents/{org}/tasks` with `{"message": {"type": "user_message", "content": "...", "timestamp": "..."}}`
 - **Get events**: `GET /api/preview/agents/{org}/tasks/{taskId}/events`
 - **Respond**: `POST /api/preview/agents/{org}/tasks/{taskId}` with `{"event": {"type": "user_message", "content": "...", "timestamp": "..."}}`
@@ -194,6 +195,7 @@ Assistant messages support markdown rendering:
 |-----|--------|
 | `i` | Enter input mode to type message |
 | `n` | Start new task/conversation |
+| `d` | Show task details dialog (only in full-width chat mode) |
 | `↑`/`↓` | Navigate task list (left panel) |
 | `j` | Scroll chat down 3 lines (newer) |
 | `k` | Scroll chat up 3 lines (older) + disable auto-scroll |
@@ -202,6 +204,31 @@ Assistant messages support markdown rendering:
 | `g` | Jump to top (oldest messages) + disable auto-scroll |
 | `G` | Jump to bottom + re-enable auto-scroll |
 | `Enter` | Load selected task's messages |
+| `Esc` | Show task list (exit full-width chat mode) |
+
+### Task Details Dialog
+Press `d` in full-width chat mode to show task details (similar to Pulumi Cloud web UI):
+- **Status**: Task state (idle, running, completed, failed)
+- **Started on**: Task creation timestamp
+- **Started by**: User who initiated the task
+- **Linked PRs**: Associated pull requests with state (open/merged/closed)
+- **Involved entities**: Stacks, environments, repositories linked to task
+- **Active policies**: Policy groups enforcing guardrails
+
+The dialog fetches fresh data from `GET /api/preview/agents/{org}/tasks/{taskId}` each time it opens.
+
+### Task Data Types
+```rust
+NeoTask {
+    id, name, status, created_at, updated_at, url,
+    started_by: Option<NeoTaskUser>,
+    linked_prs: Vec<NeoLinkedPR>,
+    entities: Vec<NeoEntity>,
+    policies: Vec<NeoPolicy>,
+}
+```
+
+Note: API may return `null` for array fields. Use custom deserializer `null_to_empty_vec` to handle this.
 
 ### Message Types (`NeoMessageType`)
 - `UserMessage` - User input

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -154,6 +154,16 @@ pub struct EscOpenResponse {
     pub values: Option<serde_json::Value>,
 }
 
+/// Helper to deserialize null as empty Vec
+fn null_to_empty_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    let opt: Option<Vec<T>> = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
+
 /// Neo Task
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -169,6 +179,75 @@ pub struct NeoTask {
     pub updated_at: Option<String>,
     #[serde(default)]
     pub url: Option<String>,
+    /// User who started the task
+    #[serde(default)]
+    pub started_by: Option<NeoTaskUser>,
+    /// Linked pull requests
+    #[serde(default, deserialize_with = "null_to_empty_vec")]
+    pub linked_prs: Vec<NeoLinkedPR>,
+    /// Involved entities (stacks, environments, etc.)
+    #[serde(default, deserialize_with = "null_to_empty_vec")]
+    pub entities: Vec<NeoEntity>,
+    /// Active policies
+    #[serde(default, deserialize_with = "null_to_empty_vec")]
+    pub policies: Vec<NeoPolicy>,
+}
+
+/// User who started a Neo task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoTaskUser {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub login: Option<String>,
+    #[serde(default)]
+    pub avatar_url: Option<String>,
+}
+
+/// Linked Pull Request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoLinkedPR {
+    #[serde(default)]
+    pub number: Option<i32>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub repository: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
+/// Entity involved in a Neo task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoEntity {
+    #[serde(rename = "type")]
+    #[serde(default)]
+    pub entity_type: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub stack: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Policy associated with a Neo task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoPolicy {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub pack_name: Option<String>,
+    #[serde(default)]
+    pub enforcement_level: Option<String>,
 }
 
 /// Neo Message type enum

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -326,4 +326,8 @@ pub mod symbols {
     pub const DIAMOND: &str = "◆";
 
     pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+    // Additional icons for entity types
+    pub const STACK: &str = "📚";
+    pub const GEAR: &str = "⚙";
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -67,6 +67,7 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
             vec![
                 ("n", "Start new task"),
                 ("i", "Focus input field"),
+                ("d", "Show task details"),
                 ("Enter", "Send/select task"),
                 ("Esc", "Show task list"),
                 ("j/k", "Scroll messages"),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,7 +18,7 @@ pub use esc::render_esc_view;
 pub use header::render_header;
 pub use help::render_help;
 pub use logs::render_logs;
-pub use neo::render_neo_view;
+pub use neo::{render_neo_view, render_neo_details_dialog};
 pub use platform::render_platform_view;
 pub use splash::render_splash;
 pub use stacks::render_stacks_view;


### PR DESCRIPTION
## Summary
- Add task details dialog showing status, started on/by, linked PRs, involved entities, and active policies
- Press `d` in full-width chat mode to fetch fresh task metadata and display the dialog
- Add `get_neo_task` API method using `GET /api/preview/agents/{org}/tasks/{taskId}` endpoint
- Add supporting types with null-safe deserialization for API responses

## Changes
- `src/ui/neo.rs` - New `render_neo_details_dialog` function
- `src/api/client.rs` - New `get_neo_task` method
- `src/api/types.rs` - Add `NeoTaskUser`, `NeoLinkedPR`, `NeoEntity`, `NeoPolicy` types
- `src/app.rs` - Key handler and `refresh_current_task_details` method
- Documentation updates in `CLAUDE.md` and help overlay

## Test plan
- [x] Build succeeds with `cargo build --release`
- [ ] Press `d` in Neo tab with active task shows details dialog
- [ ] Dialog displays task metadata correctly
- [ ] Press `d` or `Esc` closes dialog
- [ ] Dialog refreshes data each time it opens