### PR TITLE
Fix splash screen not responding to Enter key

### DIFF
--- a/src/app/handlers.rs
+++ b/src/app/handlers.rs
@@ -577,15 +577,15 @@ impl App {
                     self.splash_dont_show_again = !self.splash_dont_show_again;
                 }
             }
-            // Enter dismisses the splash (only if checks passed and not loading)
+            // Enter dismisses the splash (only if checks passed)
             KeyCode::Enter => {
-                if checks_complete && checks_passed && !self.is_loading {
+                if checks_complete && checks_passed {
                     self.dismiss_splash();
                 }
             }
-            // Escape also dismisses (only if checks passed and not loading)
+            // Escape also dismisses (only if checks passed)
             KeyCode::Esc => {
-                if checks_complete && checks_passed && !self.is_loading {
+                if checks_complete && checks_passed {
                     self.dismiss_splash();
                 }
             }


### PR DESCRIPTION
## Summary
- Fixed splash screen ignoring Enter/Esc key presses when startup checks pass
- Removed `is_loading` check that was blocking dismissal while data loaded in background
- Users can now dismiss splash immediately once checks are green

## Test plan
- [x] Run app and verify Enter dismisses splash as soon as checks pass
- [x] Verify Esc also works immediately
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)