### PR TITLE
Improve Neo chat polling and error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,9 +209,12 @@ The NEO chat uses async polling to fetch agent responses:
 - **Active polling** (after sending message): Every 500ms (5 ticks at 100ms tick rate)
 - **Background polling** (when viewing NEO tab): Every 3 seconds (30 ticks)
 - **Immediate poll**: Triggered right after task creation
+- **Task status aware**: Polls fetch both events AND task status in parallel
 - **Stop conditions** for active polling:
-  - 10 consecutive stable polls (~5 seconds) with no new messages AND has assistant response
+  - Task status is NOT "running"/"in_progress"/"pending" AND has assistant response
   - OR max 60 polls (~30 seconds timeout)
+  - OR 20+ stable polls AND task is not running (fallback)
+- **Thinking indicator**: Stays visible as long as task status is "running"
 
 ### Key State Variables (in `App`)
 - `neo_polling: bool` - Whether actively polling for responses (fast polling after sending)

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -265,6 +265,8 @@ pub enum NeoMessageType {
     AssistantMessage,
     ToolCall,
     ToolResponse,
+    /// Tool response that resulted in an error (is_error: true from API)
+    ToolError,
     ApprovalRequest,
     TaskNameChange,
 }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -33,6 +33,9 @@ pub enum NeoAsyncResult {
         messages: Vec<NeoMessage>,
         #[allow(dead_code)]
         has_more: bool,
+        /// Task status from API (e.g., "running", "idle", "completed")
+        /// Used to determine if we should keep polling/showing thinking indicator
+        task_status: Option<String>,
     },
     /// Error occurred
     Error(String),

--- a/src/ui/neo.rs
+++ b/src/ui/neo.rs
@@ -22,6 +22,7 @@ use super::markdown::render_markdown_content;
 // Tool-related symbols
 const TOOL_ICON: &str = "🔧";
 const RESULT_ICON: &str = "📋";
+const ERROR_ICON: &str = "❌";
 const APPROVAL_ICON: &str = "❓";
 const INFO_ICON: &str = "ℹ️";
 const THINKING_ICON: &str = "🤔";
@@ -288,6 +289,26 @@ fn render_chat_view(
                         lines.push(Line::from(Span::styled(
                             format!("    {}", line),
                             theme.text_muted(),
+                        )));
+                    }
+                }
+                NeoMessageType::ToolError => {
+                    // Show tool error with red error styling
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("  {} ", ERROR_ICON), theme.error()),
+                        Span::styled(
+                            format!(
+                                "Error running {}",
+                                msg.tool_name.clone().unwrap_or_else(|| "tool".to_string())
+                            ),
+                            theme.error().add_modifier(Modifier::BOLD),
+                        ),
+                    ]));
+                    // Show the error message (don't truncate as much for errors)
+                    for line in msg.content.lines().take(10) {
+                        lines.push(Line::from(Span::styled(
+                            format!("    {}", line),
+                            theme.error(),
                         )));
                     }
                 }


### PR DESCRIPTION
## Summary
- Fix thinking indicator disappearing too early by checking task status from API
- Add ToolError message type to display tool errors with red styling  
- Fix events pagination to fetch all pages (was only getting first 100)
- Show tool errors with ❌ icon and red text instead of success styling

## Test plan
- [x] Send a message to Neo and verify thinking indicator stays visible while task is running
- [x] Trigger a tool error (e.g., list_resources on large datasets) and verify red error styling
- [x] Load a task with >100 events and verify all messages are displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)