### PR TITLE
Fix splash spinner blocking and NEO thinking banner timing

### DIFF
--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -41,6 +41,15 @@ pub enum NeoAsyncResult {
     Error(String),
 }
 
+/// Startup check async result
+#[derive(Debug)]
+pub enum StartupCheckResult {
+    /// Token check completed
+    TokenCheck(crate::startup::CheckStatus),
+    /// CLI check completed
+    CliCheck(crate::startup::CheckStatus),
+}
+
 /// Application tabs/views
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {


### PR DESCRIPTION
## Summary
- Fixed splash screen spinner not animating during startup checks by making checks non-blocking
- Fixed NEO "thinking" banner disappearing prematurely by checking task status before removing it

## Test plan
- [ ] Verify splash screen spinner animates during CLI version check
- [ ] Verify NEO thinking banner stays visible while task status is "running"
- [ ] Verify banner disappears only after task status changes to non-running state