### PR TITLE
Add dashboard improvements: recent stack updates and resource count chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,41 @@ All list APIs require pagination to get accurate counts. Key details:
 - **Pagination**: Uses `continuationToken`
 - **Response**: `{ stacks: [...], continuationToken: "..." }`
 
+### Recent Stack Updates API (Console)
+- **Endpoint**: `GET /api/console/orgs/{org}/stacks/updates/recent?limit=N`
+- **Returns**: Array of stacks with their `lastUpdate` containing `requestedBy`, `info`, `version`
+- **Used for**: Dashboard "Recent Stack Updates" panel
+
+### Resource Summary API
+- **Endpoint**: `GET /api/orgs/{org}/resources/summary?granularity=daily&lookbackDays=N`
+- **Returns**: `{ summary: [{ year, month, day, resources, resourceHours }, ...] }`
+- **Used for**: Dashboard "Resource Count Over Time" chart
+
+## Dashboard Features
+
+The dashboard displays:
+
+1. **Stats Cards** (top row):
+   - Stacks count
+   - Environments count
+   - Neo Tasks count
+   - Resources count
+
+2. **Resource Count Over Time** (full-width chart):
+   - Uses ratatui `Chart` widget with `GraphType::Line` and `Marker::Braille`
+   - Shows resource count over the last 30 days
+   - X-axis: date labels (first and last date)
+   - Y-axis: resource count with auto-calculated bounds
+   - Data from `/api/orgs/{org}/resources/summary` API
+
+3. **Recent Stack Updates** (bottom left):
+   - Shows last 5 unique stack updates (deduplicated by project/stack)
+   - Format: `project / stack / Update #N` + `username updated X ago`
+   - Data from `/api/console/orgs/{org}/stacks/updates/recent` API
+
+4. **Quick Info** (bottom right):
+   - Keyboard shortcuts: Tab (views), ? (help), r (refresh)
+
 ## Ratatui LLM Chat Best Practices
 
 When building LLM chat interfaces with Ratatui:

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,6 +11,6 @@ mod types;
 
 pub use client::PulumiClient;
 pub use types::{
-    EscEnvironmentSummary, NeoMessage, NeoMessageType, NeoTask, RegistryPackage, RegistryTemplate,
-    Resource, Service, Stack,
+    EscEnvironmentSummary, NeoMessage, NeoMessageType, NeoTask, OrgStackUpdate, RegistryPackage,
+    RegistryTemplate, Resource, ResourceSummaryPoint, Service, Stack,
 };

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -4,8 +4,8 @@
 //! including enums for tabs, focus modes, and the main application state struct.
 
 use crate::api::{
-    EscEnvironmentSummary, NeoMessage, NeoTask, RegistryPackage, RegistryTemplate, Resource,
-    Service, Stack,
+    EscEnvironmentSummary, NeoMessage, NeoTask, OrgStackUpdate, RegistryPackage, RegistryTemplate,
+    Resource, ResourceSummaryPoint, Service, Stack,
 };
 
 /// Async data loading result
@@ -18,6 +18,10 @@ pub enum DataLoadResult {
     Services(Vec<Service>),
     RegistryPackages(Vec<RegistryPackage>),
     RegistryTemplates(Vec<RegistryTemplate>),
+    /// Recent stack updates across the organization
+    RecentUpdates(Vec<OrgStackUpdate>),
+    /// Resource count over time (for dashboard chart)
+    ResourceSummary(Vec<ResourceSummaryPoint>),
     /// README content loaded for a package (key, content)
     ReadmeContent { package_key: String, content: String },
     Error(String),
@@ -173,6 +177,10 @@ pub struct AppState {
     pub esc_environments: Vec<EscEnvironmentSummary>,
     pub neo_tasks: Vec<NeoTask>,
     pub resources: Vec<Resource>,
+    /// Recent stack updates across the organization (for dashboard)
+    pub recent_updates: Vec<OrgStackUpdate>,
+    /// Resource count over time (for dashboard chart)
+    pub resource_summary: Vec<ResourceSummaryPoint>,
 
     // Selected stack details
     pub selected_stack_updates: Vec<(i32, String, String)>,
@@ -202,6 +210,8 @@ impl Default for AppState {
             esc_environments: Vec::new(),
             neo_tasks: Vec::new(),
             resources: Vec::new(),
+            recent_updates: Vec::new(),
+            resource_summary: Vec::new(),
             selected_stack_updates: Vec::new(),
             selected_env_yaml: None,
             selected_env_values: None,

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -3,12 +3,49 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     prelude::*,
+    symbols::Marker,
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, Paragraph},
 };
 
 use crate::app::AppState;
 use crate::theme::{symbols, Theme};
+
+/// Format a unix timestamp as relative time (e.g., "2 days ago", "3 hours ago")
+fn format_time_ago(timestamp: i64) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let diff = now - timestamp;
+
+    if diff < 0 {
+        return "just now".to_string();
+    }
+
+    let minutes = diff / 60;
+    let hours = diff / 3600;
+    let days = diff / 86400;
+
+    if days > 0 {
+        if days == 1 {
+            "1 day ago".to_string()
+        } else {
+            format!("{} days ago", days)
+        }
+    } else if hours > 0 {
+        if hours == 1 {
+            "1 hour ago".to_string()
+        } else {
+            format!("{} hours ago", hours)
+        }
+    } else if minutes > 0 {
+        if minutes == 1 {
+            "1 min ago".to_string()
+        } else {
+            format!("{} mins ago", minutes)
+        }
+    } else {
+        "just now".to_string()
+    }
+}
 
 /// Render the dashboard view
 pub fn render_dashboard(frame: &mut Frame, theme: &Theme, area: Rect, state: &AppState) {
@@ -124,81 +161,207 @@ fn render_stat_card(
 }
 
 fn render_recent_activity(frame: &mut Frame, theme: &Theme, area: Rect, state: &AppState) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+    // Layout: Resource chart (full width) on top, then updates + quick info below
+    let main_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(10), Constraint::Min(5)])
         .split(area);
 
-    // Recent stacks
-    let stacks_block = Block::default()
+    // Resource count over time chart (full width)
+    render_resource_chart(frame, theme, main_chunks[0], state);
+
+    // Bottom row: Recent updates (left) + Quick info (right, smaller)
+    let bottom_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(75), Constraint::Percentage(25)])
+        .split(main_chunks[1]);
+
+    // Recent stack updates
+    let updates_block = Block::default()
         .borders(Borders::ALL)
         .border_style(theme.border())
-        .title(" Recent Stacks ")
+        .title(" Recent Stack Updates ")
         .title_style(theme.subtitle());
 
-    let stacks_inner = stacks_block.inner(chunks[0]);
-    frame.render_widget(stacks_block, chunks[0]);
+    let updates_inner = updates_block.inner(bottom_chunks[0]);
+    frame.render_widget(updates_block, bottom_chunks[0]);
 
-    let stack_lines: Vec<Line> = state
-        .stacks
+    // Deduplicate: only show the latest update per project/stack
+    let mut seen_stacks: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let unique_updates: Vec<_> = state
+        .recent_updates
         .iter()
-        .take(10)
-        .map(|s| {
-            Line::from(vec![
-                Span::styled(
-                    format!("{} ", symbols::ARROW_RIGHT),
-                    theme.primary(),
-                ),
-                Span::styled(&s.project_name, theme.text()),
-                Span::styled("/", theme.text_muted()),
-                Span::styled(&s.stack_name, theme.highlight()),
-                Span::styled(
-                    format!("  {}", s.last_update_formatted()),
-                    theme.text_muted(),
-                ),
-            ])
+        .filter(|u| {
+            let key = format!("{}/{}", u.project_name, u.stack_name);
+            if seen_stacks.contains(&key) {
+                false
+            } else {
+                seen_stacks.insert(key);
+                true
+            }
         })
+        .take(5)
         .collect();
 
-    let stacks_para = Paragraph::new(stack_lines).wrap(ratatui::widgets::Wrap { trim: true });
-    frame.render_widget(stacks_para, stacks_inner);
+    // Build two lines per update (like Pulumi Cloud UI)
+    let mut update_lines: Vec<Line> = Vec::new();
+    for u in unique_updates.iter() {
+        // Format relative time
+        let time_ago = format_time_ago(u.start_time);
+        let username = u.requested_by.as_deref().unwrap_or("unknown");
 
-    // Activity sparkline / info panel
+        // Line 1: project / stack / Update #N
+        update_lines.push(Line::from(vec![
+            Span::styled(format!("{} ", symbols::DIAMOND), theme.primary()),
+            Span::styled(&u.project_name, theme.text()),
+            Span::styled(" / ", theme.text_muted()),
+            Span::styled(&u.stack_name, theme.highlight()),
+            Span::styled(" / ", theme.text_muted()),
+            Span::styled(format!("Update #{}", u.version), theme.text_secondary()),
+        ]));
+
+        // Line 2: username updated X days ago
+        update_lines.push(Line::from(vec![
+            Span::styled("  ", Style::default()), // indent
+            Span::styled(username, theme.text_muted()),
+            Span::styled(" updated ", theme.text_muted()),
+            Span::styled(time_ago, theme.text_muted()),
+        ]));
+    }
+
+    if update_lines.is_empty() {
+        let empty_msg = Paragraph::new(Line::from(vec![
+            Span::styled("No recent updates", theme.text_muted()),
+        ]));
+        frame.render_widget(empty_msg, updates_inner);
+    } else {
+        let updates_para = Paragraph::new(update_lines);
+        frame.render_widget(updates_para, updates_inner);
+    }
+
+    // Quick Info panel (smaller, on right)
     let info_block = Block::default()
         .borders(Borders::ALL)
         .border_style(theme.border())
         .title(" Quick Info ")
         .title_style(theme.subtitle());
 
-    let info_inner = info_block.inner(chunks[1]);
-    frame.render_widget(info_block, chunks[1]);
+    let info_inner = info_block.inner(bottom_chunks[1]);
+    frame.render_widget(info_block, bottom_chunks[1]);
 
     let info_lines = vec![
         Line::from(vec![
-            Span::styled("Press ", theme.text_secondary()),
             Span::styled("Tab", theme.key_hint()),
-            Span::styled(" to switch views", theme.text_secondary()),
+            Span::styled(" views", theme.text_muted()),
         ]),
-        Line::from(""),
         Line::from(vec![
-            Span::styled("Press ", theme.text_secondary()),
             Span::styled("?", theme.key_hint()),
-            Span::styled(" for help", theme.text_secondary()),
+            Span::styled(" help", theme.text_muted()),
         ]),
-        Line::from(""),
         Line::from(vec![
-            Span::styled("Press ", theme.text_secondary()),
-            Span::styled("q", theme.key_hint()),
-            Span::styled(" to quit", theme.text_secondary()),
-        ]),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("Press ", theme.text_secondary()),
             Span::styled("r", theme.key_hint()),
-            Span::styled(" to refresh", theme.text_secondary()),
+            Span::styled(" refresh", theme.text_muted()),
         ]),
     ];
 
     let info_para = Paragraph::new(info_lines);
     frame.render_widget(info_para, info_inner);
+}
+
+/// Render resource count over time chart using Chart widget
+fn render_resource_chart(frame: &mut Frame, theme: &Theme, area: Rect, state: &AppState) {
+    if state.resource_summary.is_empty() {
+        let empty_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.border())
+            .title(" Resource Count Over Time ")
+            .title_style(theme.subtitle());
+        let inner = empty_block.inner(area);
+        frame.render_widget(empty_block, area);
+        let empty_msg = Paragraph::new(Line::from(vec![Span::styled(
+            "No resource data",
+            theme.text_muted(),
+        )]));
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    // Convert data to (f64, f64) tuples for Chart widget
+    let data: Vec<(f64, f64)> = state
+        .resource_summary
+        .iter()
+        .enumerate()
+        .map(|(i, point)| (i as f64, point.resources as f64))
+        .collect();
+
+    // Calculate bounds
+    let max_x = data.len() as f64;
+    let max_y = data
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(0.0_f64, |a, b| a.max(b));
+    let min_y = data
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::MAX, |a, b| a.min(b));
+
+    // Add some padding to y bounds
+    let y_padding = ((max_y - min_y) * 0.1).max(5.0);
+    let y_min = (min_y - y_padding).max(0.0);
+    let y_max = max_y + y_padding;
+
+    // Get date labels for x-axis
+    let first_label = state
+        .resource_summary
+        .first()
+        .map(|p| p.date_label())
+        .unwrap_or_default();
+    let last_label = state
+        .resource_summary
+        .last()
+        .map(|p| p.date_label())
+        .unwrap_or_default();
+
+    // Current resource count for title
+    let current_count = state
+        .resource_summary
+        .last()
+        .map(|p| p.resources)
+        .unwrap_or(0);
+
+    let datasets = vec![Dataset::default()
+        .name(format!("{} resources", current_count))
+        .marker(Marker::Braille)
+        .graph_type(GraphType::Line)
+        .style(Style::default().fg(theme.primary))
+        .data(&data)];
+
+    let chart = Chart::new(datasets)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme.border())
+                .title(" Resource Count Over Time ")
+                .title_style(theme.subtitle()),
+        )
+        .x_axis(
+            Axis::default()
+                .style(theme.text_muted())
+                .bounds([0.0, max_x])
+                .labels(vec![
+                    Span::styled(first_label, theme.text_muted()),
+                    Span::styled(last_label, theme.text_muted()),
+                ]),
+        )
+        .y_axis(
+            Axis::default()
+                .style(theme.text_muted())
+                .bounds([y_min, y_max])
+                .labels(vec![
+                    Span::styled(format!("{:.0}", y_min), theme.text_muted()),
+                    Span::styled(format!("{:.0}", y_max), theme.text_muted()),
+                ]),
+        );
+
+    frame.render_widget(chart, area);
 }


### PR DESCRIPTION
## Summary
- Replace "Recent Stacks" with "Recent Stack Updates" panel showing deduplicated updates with username and relative time
- Add full-width "Resource Count Over Time" line chart using ratatui Chart widget
- Reorganize dashboard layout with resource chart on top, updates and quick info below
- Add new API types and methods for recent updates and resource summary

## Changes
- **Dashboard UI**: Full-width resource chart (30 days), recent stack updates panel, condensed quick info
- **API Client**: New methods `get_org_recent_updates()` and `get_resource_summary()`
- **API Types**: `OrgStackUpdate`, `ResourceSummaryPoint`, `ResourceSummaryResponse`
- **Documentation**: Updated CLAUDE.md with dashboard features and new API endpoints

## Test plan
- [ ] Verify dashboard loads with resource count chart
- [ ] Verify recent stack updates show deduplicated entries with usernames
- [ ] Verify chart displays correct data from resource summary API
- [ ] Verify quick info panel displays keyboard shortcuts