### PR TITLE
Add ESC environment YAML editor with syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,10 +1098,12 @@ dependencies = [
  "crossterm",
  "directories",
  "image",
+ "once_cell",
  "ratatui",
  "reqwest",
  "serde",
  "serde_json",
+ "syntect",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1343,6 +1354,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1439,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -1848,6 +1887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2113,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.17",
+ "walkdir",
 ]
 
 [[package]]
@@ -2408,6 +2474,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2615,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ chrono = { version = "0.4", features = ["serde"] }
 directories = "5"
 urlencoding = "2"
 
+# Syntax Highlighting
+syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
+once_cell = "1"
+
 # Logging (optional, for debugging)
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -213,18 +213,31 @@ pub struct EscEnvironmentSummary {
 }
 
 /// ESC Environment details
+/// Note: The API response varies - may include yaml, definition, or other fields
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EscEnvironmentDetails {
     #[serde(default)]
     pub yaml: Option<String>,
     #[serde(default)]
     pub definition: Option<serde_json::Value>,
+    // Additional fields that might be present
+    #[serde(default)]
+    pub created: Option<String>,
+    #[serde(default)]
+    pub modified: Option<String>,
+    #[serde(default)]
+    pub revision: Option<i64>,
+    // Catch any other fields
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// ESC Open session response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EscOpenResponse {
-    pub id: String,
+    #[serde(default)]
+    pub id: Option<String>,
     #[serde(default)]
     pub properties: Option<serde_json::Value>,
     #[serde(default)]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -118,6 +118,23 @@ pub enum FocusMode {
     Input,
 }
 
+/// ESC detail pane selection (which content pane is focused)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EscPane {
+    #[default]
+    Definition,
+    ResolvedValues,
+}
+
+impl EscPane {
+    pub fn toggle(&self) -> Self {
+        match self {
+            EscPane::Definition => EscPane::ResolvedValues,
+            EscPane::ResolvedValues => EscPane::Definition,
+        }
+    }
+}
+
 /// Platform sub-view selection
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlatformView {

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1,0 +1,320 @@
+//! Multi-line text editor component for YAML editing
+
+use crossterm::event::KeyEvent;
+use crate::event::keys;
+
+/// A multi-line text editor with cursor support
+#[derive(Debug, Clone)]
+pub struct TextEditor {
+    /// Lines of text
+    lines: Vec<String>,
+    /// Cursor row (line index)
+    row: usize,
+    /// Cursor column (character index within line)
+    col: usize,
+    /// Scroll offset (first visible line)
+    scroll_offset: usize,
+    /// Visible height (for scrolling)
+    visible_height: usize,
+    /// Whether the editor has been modified
+    modified: bool,
+}
+
+impl Default for TextEditor {
+    fn default() -> Self {
+        Self {
+            lines: vec![String::new()],
+            row: 0,
+            col: 0,
+            scroll_offset: 0,
+            visible_height: 20,
+            modified: false,
+        }
+    }
+}
+
+impl TextEditor {
+    /// Create a new text editor
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create editor with initial content
+    pub fn with_content(content: &str) -> Self {
+        let lines: Vec<String> = if content.is_empty() {
+            vec![String::new()]
+        } else {
+            content.lines().map(|l| l.to_string()).collect()
+        };
+
+        // Ensure at least one line
+        let lines = if lines.is_empty() { vec![String::new()] } else { lines };
+
+        Self {
+            lines,
+            row: 0,
+            col: 0,
+            scroll_offset: 0,
+            visible_height: 20,
+            modified: false,
+        }
+    }
+
+    /// Set the visible height for scrolling
+    pub fn set_visible_height(&mut self, height: usize) {
+        self.visible_height = height.max(1);
+        self.ensure_cursor_visible();
+    }
+
+    /// Get all content as a single string
+    pub fn content(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    /// Get lines for rendering
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+
+    /// Get current cursor position (row, col)
+    pub fn cursor(&self) -> (usize, usize) {
+        (self.row, self.col)
+    }
+
+    /// Get scroll offset
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    /// Check if modified
+    pub fn is_modified(&self) -> bool {
+        self.modified
+    }
+
+    /// Get total line count
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Get current line
+    pub fn current_line(&self) -> &str {
+        &self.lines[self.row]
+    }
+
+    /// Ensure cursor is visible (adjust scroll)
+    fn ensure_cursor_visible(&mut self) {
+        if self.row < self.scroll_offset {
+            self.scroll_offset = self.row;
+        } else if self.row >= self.scroll_offset + self.visible_height {
+            self.scroll_offset = self.row.saturating_sub(self.visible_height - 1);
+        }
+    }
+
+    /// Clamp column to valid range for current line
+    fn clamp_col(&mut self) {
+        let line_len = self.lines[self.row].len();
+        if self.col > line_len {
+            self.col = line_len;
+        }
+    }
+
+    /// Handle a key event, returns true if handled
+    pub fn handle_key(&mut self, key: &KeyEvent) -> bool {
+        // Character input
+        if let Some(c) = keys::get_char(key) {
+            self.insert_char(c);
+            return true;
+        }
+
+        // Navigation
+        if keys::is_up(key) {
+            self.move_up();
+            return true;
+        }
+        if keys::is_down(key) {
+            self.move_down();
+            return true;
+        }
+        if keys::is_left(key) {
+            self.move_left();
+            return true;
+        }
+        if keys::is_right(key) {
+            self.move_right();
+            return true;
+        }
+        if keys::is_home(key) {
+            self.col = 0;
+            return true;
+        }
+        if keys::is_end(key) {
+            self.col = self.lines[self.row].len();
+            return true;
+        }
+        if keys::is_page_up(key) {
+            self.page_up();
+            return true;
+        }
+        if keys::is_page_down(key) {
+            self.page_down();
+            return true;
+        }
+
+        // Editing
+        if keys::is_enter(key) {
+            self.insert_newline();
+            return true;
+        }
+        if keys::is_backspace(key) {
+            self.backspace();
+            return true;
+        }
+        if keys::is_delete(key) {
+            self.delete();
+            return true;
+        }
+        if keys::is_tab(key) {
+            // Insert 2 spaces for YAML indentation
+            self.insert_char(' ');
+            self.insert_char(' ');
+            return true;
+        }
+
+        // Ctrl shortcuts
+        if keys::is_ctrl_char(key, 'u') {
+            // Clear line before cursor
+            self.lines[self.row] = self.lines[self.row][self.col..].to_string();
+            self.col = 0;
+            self.modified = true;
+            return true;
+        }
+        if keys::is_ctrl_char(key, 'k') {
+            // Clear line after cursor
+            self.lines[self.row].truncate(self.col);
+            self.modified = true;
+            return true;
+        }
+        if keys::is_ctrl_char(key, 'a') {
+            // Go to beginning of line
+            self.col = 0;
+            return true;
+        }
+        if keys::is_ctrl_char(key, 'e') {
+            // Go to end of line
+            self.col = self.lines[self.row].len();
+            return true;
+        }
+        if keys::is_ctrl_char(key, 'd') {
+            // Delete line
+            if self.lines.len() > 1 {
+                self.lines.remove(self.row);
+                if self.row >= self.lines.len() {
+                    self.row = self.lines.len() - 1;
+                }
+                self.clamp_col();
+                self.ensure_cursor_visible();
+                self.modified = true;
+            } else {
+                self.lines[0].clear();
+                self.col = 0;
+                self.modified = true;
+            }
+            return true;
+        }
+
+        false
+    }
+
+    fn insert_char(&mut self, c: char) {
+        self.lines[self.row].insert(self.col, c);
+        self.col += 1;
+        self.modified = true;
+    }
+
+    fn insert_newline(&mut self) {
+        let rest = self.lines[self.row].split_off(self.col);
+        self.row += 1;
+        self.lines.insert(self.row, rest);
+        self.col = 0;
+        self.ensure_cursor_visible();
+        self.modified = true;
+    }
+
+    fn backspace(&mut self) {
+        if self.col > 0 {
+            self.col -= 1;
+            self.lines[self.row].remove(self.col);
+            self.modified = true;
+        } else if self.row > 0 {
+            // Merge with previous line
+            let current_line = self.lines.remove(self.row);
+            self.row -= 1;
+            self.col = self.lines[self.row].len();
+            self.lines[self.row].push_str(&current_line);
+            self.ensure_cursor_visible();
+            self.modified = true;
+        }
+    }
+
+    fn delete(&mut self) {
+        if self.col < self.lines[self.row].len() {
+            self.lines[self.row].remove(self.col);
+            self.modified = true;
+        } else if self.row + 1 < self.lines.len() {
+            // Merge with next line
+            let next_line = self.lines.remove(self.row + 1);
+            self.lines[self.row].push_str(&next_line);
+            self.modified = true;
+        }
+    }
+
+    fn move_up(&mut self) {
+        if self.row > 0 {
+            self.row -= 1;
+            self.clamp_col();
+            self.ensure_cursor_visible();
+        }
+    }
+
+    fn move_down(&mut self) {
+        if self.row + 1 < self.lines.len() {
+            self.row += 1;
+            self.clamp_col();
+            self.ensure_cursor_visible();
+        }
+    }
+
+    fn move_left(&mut self) {
+        if self.col > 0 {
+            self.col -= 1;
+        } else if self.row > 0 {
+            self.row -= 1;
+            self.col = self.lines[self.row].len();
+            self.ensure_cursor_visible();
+        }
+    }
+
+    fn move_right(&mut self) {
+        if self.col < self.lines[self.row].len() {
+            self.col += 1;
+        } else if self.row + 1 < self.lines.len() {
+            self.row += 1;
+            self.col = 0;
+            self.ensure_cursor_visible();
+        }
+    }
+
+    fn page_up(&mut self) {
+        let jump = self.visible_height.saturating_sub(2);
+        self.row = self.row.saturating_sub(jump);
+        self.scroll_offset = self.scroll_offset.saturating_sub(jump);
+        self.clamp_col();
+    }
+
+    fn page_down(&mut self) {
+        let jump = self.visible_height.saturating_sub(2);
+        self.row = (self.row + jump).min(self.lines.len().saturating_sub(1));
+        self.ensure_cursor_visible();
+        self.clamp_col();
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,9 +1,11 @@
 //! Reusable UI components
 
+mod editor;
 mod input;
 mod list;
 mod spinner;
 
+pub use editor::TextEditor;
 pub use input::TextInput;
 pub use list::StatefulList;
 pub use spinner::Spinner;

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -58,8 +58,14 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
         (
             "Environment View",
             vec![
+                ("↑/↓", "Navigate environment list"),
+                ("←/→ or h/l", "Switch focus: Definition / Values"),
+                ("j/k", "Scroll focused pane"),
+                ("J/K", "Page scroll focused pane"),
                 ("Enter", "Load environment definition"),
                 ("o", "Open & resolve environment values"),
+                ("e", "Edit environment YAML"),
+                ("O", "Select organization (in this tab)"),
             ],
         ),
         (

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,9 +12,10 @@ mod neo;
 mod platform;
 mod splash;
 mod stacks;
+pub mod syntax;
 
 pub use dashboard::render_dashboard;
-pub use esc::render_esc_view;
+pub use esc::{render_esc_view, render_esc_editor};
 pub use header::render_header;
 pub use help::render_help;
 pub use logs::render_logs;

--- a/src/ui/syntax.rs
+++ b/src/ui/syntax.rs
@@ -1,0 +1,98 @@
+//! Syntax highlighting utilities using syntect
+
+use once_cell::sync::Lazy;
+use ratatui::style::Style as RatatuiStyle;
+use ratatui::text::{Line, Span};
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Style as SyntectStyle, ThemeSet};
+use syntect::parsing::SyntaxSet;
+use syntect::util::LinesWithEndings;
+
+/// Lazy-loaded syntax set with default syntaxes
+static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
+
+/// Lazy-loaded theme set with default themes
+static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+
+/// Convert syntect style to ratatui style with owned content
+fn syntect_to_ratatui_span(style: SyntectStyle, content: &str) -> Span<'static> {
+    let fg = ratatui::style::Color::Rgb(
+        style.foreground.r,
+        style.foreground.g,
+        style.foreground.b,
+    );
+
+    Span::styled(
+        content.to_string(),
+        RatatuiStyle::default().fg(fg),
+    )
+}
+
+/// Highlight YAML content and return ratatui Lines
+pub fn highlight_yaml(content: &str) -> Vec<Line<'static>> {
+    let syntax = SYNTAX_SET
+        .find_syntax_by_extension("yaml")
+        .or_else(|| SYNTAX_SET.find_syntax_by_extension("yml"))
+        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
+
+    // Use a dark theme that works well in terminals
+    let theme = THEME_SET
+        .themes
+        .get("base16-ocean.dark")
+        .or_else(|| THEME_SET.themes.get("base16-eighties.dark"))
+        .unwrap_or_else(|| THEME_SET.themes.values().next().unwrap());
+
+    let mut highlighter = HighlightLines::new(syntax, theme);
+    let mut lines = Vec::new();
+
+    for line in LinesWithEndings::from(content) {
+        match highlighter.highlight_line(line, &SYNTAX_SET) {
+            Ok(highlighted) => {
+                let spans: Vec<Span<'static>> = highlighted
+                    .into_iter()
+                    .map(|(style, text)| syntect_to_ratatui_span(style, text))
+                    .collect();
+                lines.push(Line::from(spans));
+            }
+            Err(_) => {
+                // Fallback to plain text if highlighting fails
+                lines.push(Line::from(line.trim_end().to_string()));
+            }
+        }
+    }
+
+    lines
+}
+
+/// Highlight JSON content and return ratatui Lines
+pub fn highlight_json(content: &str) -> Vec<Line<'static>> {
+    let syntax = SYNTAX_SET
+        .find_syntax_by_extension("json")
+        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
+
+    let theme = THEME_SET
+        .themes
+        .get("base16-ocean.dark")
+        .or_else(|| THEME_SET.themes.get("base16-eighties.dark"))
+        .unwrap_or_else(|| THEME_SET.themes.values().next().unwrap());
+
+    let mut highlighter = HighlightLines::new(syntax, theme);
+    let mut lines = Vec::new();
+
+    for line in LinesWithEndings::from(content) {
+        match highlighter.highlight_line(line, &SYNTAX_SET) {
+            Ok(highlighted) => {
+                let spans: Vec<Span<'static>> = highlighted
+                    .into_iter()
+                    .map(|(style, text)| syntect_to_ratatui_span(style, text))
+                    .collect();
+                lines.push(Line::from(spans));
+            }
+            Err(_) => {
+                lines.push(Line::from(line.trim_end().to_string()));
+            }
+        }
+    }
+
+    lines
+}


### PR DESCRIPTION
## Summary
- Add `TextEditor` component for multi-line YAML editing with full cursor navigation
- Add YAML editor dialog accessible via `e` key when an ESC environment is selected
- Implement syntax highlighting using syntect crate for better YAML authoring experience
- Add API method to update ESC environment definitions via `PATCH` endpoint
- Fix resolved values pane showing JSON schema instead of actual property values
- Remove secret masking to display full values in resolved view

## Test plan
- [ ] Navigate to ESC tab and select an environment
- [ ] Press `e` to open the editor dialog
- [ ] Verify YAML syntax highlighting is visible
- [ ] Test cursor navigation (arrows, Home, End, Page Up/Down)
- [ ] Test text editing (insert, delete, backspace, Enter for newlines)
- [ ] Test Tab key inserts 2-space indentation
- [ ] Press `Esc` to save changes and verify API call succeeds
- [ ] Press `Ctrl+C` to cancel without saving
- [ ] Verify resolved values pane shows actual values, not schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)