### PR TITLE
Use tui-big-text for dashboard stat card numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,7 @@ The dashboard displays:
    - Environments count
    - Neo Tasks count
    - Resources count
+   - Uses `tui-big-text` crate with `PixelSize::Quadrant` for large, centered numbers
 
 2. **Resource Count Over Time** (full-width chart):
    - Uses ratatui `Chart` widget with `GraphType::Line` and `Marker::Braille`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +634,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
 
 [[package]]
 name = "form_urlencoded"
@@ -1108,6 +1145,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tui-big-text",
  "tui-scrollview",
  "urlencoding",
 ]
@@ -2380,6 +2418,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-big-text"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7876e22ef305de349de2ef40197455a84980f1597277ce7fb2008989b19c572"
+dependencies = [
+ "derive_builder",
+ "font8x8",
+ "itertools 0.14.0",
+ "ratatui",
+]
 
 [[package]]
 name = "tui-scrollview"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28"
 tui-scrollview = "0.5"
+tui-big-text = "0.7"
 
 # Async Runtime
 tokio = { version = "1", features = ["full"] }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -127,6 +127,7 @@ pub enum EscPane {
 }
 
 impl EscPane {
+    #[allow(dead_code)]
     pub fn toggle(&self) -> Self {
         match self {
             EscPane::Definition => EscPane::ResolvedValues,

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -61,6 +61,7 @@ impl TextEditor {
     }
 
     /// Set the visible height for scrolling
+    #[allow(dead_code)]
     pub fn set_visible_height(&mut self, height: usize) {
         self.visible_height = height.max(1);
         self.ensure_cursor_visible();
@@ -92,11 +93,13 @@ impl TextEditor {
     }
 
     /// Get total line count
+    #[allow(dead_code)]
     pub fn line_count(&self) -> usize {
         self.lines.len()
     }
 
     /// Get current line
+    #[allow(dead_code)]
     pub fn current_line(&self) -> &str {
         &self.lines[self.row]
     }

--- a/src/ui/syntax.rs
+++ b/src/ui/syntax.rs
@@ -65,6 +65,7 @@ pub fn highlight_yaml(content: &str) -> Vec<Line<'static>> {
 }
 
 /// Highlight JSON content and return ratatui Lines
+#[allow(dead_code)]
 pub fn highlight_json(content: &str) -> Vec<Line<'static>> {
     let syntax = SYNTAX_SET
         .find_syntax_by_extension("json")


### PR DESCRIPTION
## Summary
- Replace small text numbers with large, centered BigText display using the `tui-big-text` crate
- Numbers use `PixelSize::Quadrant` for a balanced size and are vertically/horizontally centered
- Fix unused code warnings by adding `#[allow(dead_code)]` attributes

## Test plan
- [ ] Run the application and verify dashboard stat cards show large numbers
- [ ] Verify numbers are centered within each card
- [ ] Verify build completes without warnings