### PR TITLE
Replace file-based logging with tui-logger widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,28 +23,39 @@ RUST_LOG=debug cargo run --release
 
 ## Logging
 
-Logs are written to a file instead of stdout to avoid interfering with the TUI:
-- **Log file location**: `~/.cache/lazy-pulumi/app.log`
-- Press `l` globally to open the log viewer popup
-- Logs are color-coded by level (ERROR=red, WARN=yellow, INFO=blue, DEBUG=muted)
+The application uses `tui-logger` for integrated in-app log viewing. Press `l` globally to open the log viewer popup.
+
+### Log Viewer Features
+- **Smart Widget**: Combined target selector (left) and log messages view (right)
+- **Target filtering**: Filter logs by module/target with real-time level control
+- **Scrollback**: Navigate through log history with page mode
+- **Log levels**: Color-coded ERROR (red), WARN (yellow), INFO (blue), DEBUG/TRACE (muted)
 
 ### Log Viewer Key Bindings
 | Key | Action |
 |-----|--------|
 | `l` or `Esc` | Close logs |
-| `w` | Toggle word wrap on/off |
-| `j` / `↓` | Scroll down 3 lines |
-| `k` / `↑` | Scroll up 3 lines |
-| `J` / `PageDown` | Scroll down by page |
-| `K` / `PageUp` | Scroll up by page |
-| `g` | Jump to top |
-| `G` | Jump to bottom |
-| `R` | Refresh logs |
+| `h` | Toggle target selector panel visibility |
+| `f` | Toggle focus on selected target only |
+| `↑` / `↓` | Select previous/next target |
+| `←` or `<` | Reduce SHOWN log level for target |
+| `→` or `>` | Increase SHOWN log level for target |
+| `-` | Reduce CAPTURED log level for target |
+| `+` or `=` | Increase CAPTURED log level for target |
+| `PageUp` | Enter page mode, scroll up in history |
+| `PageDown` | Scroll down in history (page mode only) |
+| `Space` | Toggle hiding targets with logfilter off |
+
+### Target Selector Columns
+The target selector shows two columns (EWIDT = Error, Warn, Info, Debug, Trace):
+- **Inverted letters**: Log levels shown in the messages view
+- **Normal letters**: Log levels being captured by the logger
+- If a letter is missing, that level is not captured
 
 ### Implementation
-- `src/logging.rs` - File-based logging initialization and log reading
-- `src/ui/logs.rs` - Log viewer popup rendering with word wrap support
-- Logs are cached when viewer opens; press `R` to reload from file
+- `src/logging.rs` - tui-logger initialization using `log` crate
+- `src/ui/logs.rs` - TuiLoggerSmartWidget rendering
+- Uses `TuiWidgetState` for managing filter state and scroll position
 
 ## Required Environment Variables
 
@@ -132,7 +143,7 @@ src/
 │   └── ...                 # Other UI components
 ├── config.rs               # User configuration
 ├── event.rs                # Async event handler
-├── logging.rs              # File-based logging
+├── logging.rs              # tui-logger initialization
 ├── startup.rs              # Startup checks
 ├── theme.rs                # UI theme/colors
 ├── tui.rs                  # Terminal setup/teardown
@@ -193,7 +204,7 @@ Views in `src/ui/` render to Ratatui frames:
 
 ### Application Flow
 
-1. `main.rs` initializes color-eyre, tracing, creates `App`, and calls `app.run()`
+1. `main.rs` initializes color-eyre, tui-logger, creates `App`, and calls `app.run()`
 2. `App::new()` sets up terminal, event handler, API client, loads initial data
 3. `App::run()` enters async loop: render frame → poll events → handle input
 4. `handlers.rs` dispatches to tab-specific handlers (`handle_stacks_key`, `handle_esc_key`, `handle_neo_key`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1145,7 @@ dependencies = [
  "crossterm",
  "directories",
  "image",
+ "log",
  "once_cell",
  "ratatui",
  "reqwest",
@@ -1143,9 +1154,8 @@ dependencies = [
  "syntect",
  "thiserror 2.0.17",
  "tokio",
- "tracing",
- "tracing-subscriber",
  "tui-big-text",
+ "tui-logger",
  "tui-scrollview",
  "urlencoding",
 ]
@@ -1240,15 +1250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,15 +1317,6 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "num-bigint"
@@ -1775,6 +1767,18 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2349,19 +2353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2385,32 +2377,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -2429,6 +2403,21 @@ dependencies = [
  "font8x8",
  "itertools 0.14.0",
  "ratatui",
+]
+
+[[package]]
+name = "tui-logger"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382b7ea88082dbe2236ed1e942552b1bfc59e98fdc5d0599f11a627aae9ee2be"
+dependencies = [
+ "chrono",
+ "env_filter",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "ratatui",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3014,18 +3003,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ urlencoding = "2"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
 once_cell = "1"
 
-# Logging (optional, for debugging)
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Logging
+log = "0.4"
+tui-logger = "0.17"
 
 # Image processing for splash screen
 image = "0.25"

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -252,7 +252,7 @@ impl App {
                     self.stacks_list.set_items(stacks);
                 }
                 DataLoadResult::EscEnvironments(envs) => {
-                    tracing::info!("Received {} ESC environments", envs.len());
+                    log::info!("Received {} ESC environments", envs.len());
                     self.state.esc_environments = envs.clone();
                     self.esc_list.set_items(envs);
                 }
@@ -296,7 +296,7 @@ impl App {
                     }
                 }
                 DataLoadResult::Error(e) => {
-                    tracing::warn!("Data load error: {}", e);
+                    log::warn!("Data load error: {}", e);
                 }
             }
 
@@ -335,7 +335,7 @@ impl App {
                                 .await;
                         }
                         Err(e) => {
-                            tracing::debug!("Failed to load README: {}", e);
+                            log::debug!("Failed to load README: {}", e);
                         }
                     }
                 });

--- a/src/app/neo.rs
+++ b/src/app/neo.rs
@@ -113,7 +113,7 @@ impl App {
                         || self.neo_current_poll >= self.neo_max_polls
                         || (self.neo_stable_polls >= 20 && !task_is_running);
 
-                    tracing::debug!(
+                    log::debug!(
                         "Neo poll: status={:?}, running={}, stable={}, poll={}/{}, stop={}",
                         task_status, task_is_running, self.neo_stable_polls,
                         self.neo_current_poll, self.neo_max_polls, should_stop
@@ -178,7 +178,7 @@ impl App {
                                 .await;
                         }
                         Err(e) => {
-                            tracing::warn!("Failed to poll Neo task: {}", e);
+                            log::warn!("Failed to poll Neo task: {}", e);
                             // Don't send error for transient poll failures
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,12 +48,12 @@ impl Config {
                     match serde_json::from_str(&contents) {
                         Ok(config) => return config,
                         Err(e) => {
-                            tracing::warn!("Failed to parse config: {}", e);
+                            log::warn!("Failed to parse config: {}", e);
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to read config: {}", e);
+                    log::warn!("Failed to read config: {}", e);
                 }
             }
         }
@@ -69,11 +69,11 @@ impl Config {
         match serde_json::to_string_pretty(self) {
             Ok(contents) => {
                 if let Err(e) = fs::write(&path, contents) {
-                    tracing::warn!("Failed to save config: {}", e);
+                    log::warn!("Failed to save config: {}", e);
                 }
             }
             Err(e) => {
-                tracing::warn!("Failed to serialize config: {}", e);
+                log::warn!("Failed to serialize config: {}", e);
             }
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,96 +1,25 @@
-//! File-based logging module
+//! Logging module using tui-logger
 //!
-//! Redirects tracing output to a file to avoid interfering with the TUI.
+//! Provides a TUI-integrated logging system that can be displayed in a popup widget.
 
 use color_eyre::Result;
-use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
-use std::sync::OnceLock;
-use tracing_subscriber::prelude::*;
+use log::LevelFilter;
 
-/// Global log file path
-static LOG_FILE_PATH: OnceLock<PathBuf> = OnceLock::new();
+/// Initialize the tui-logger system
+pub fn init_logging() -> Result<()> {
+    // Initialize tui-logger with max level Trace
+    tui_logger::init_logger(LevelFilter::Trace)
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to init logger: {}", e))?;
 
-/// Get the log file path
-pub fn log_file_path() -> PathBuf {
-    LOG_FILE_PATH
-        .get()
-        .cloned()
-        .unwrap_or_else(|| {
-            directories::BaseDirs::new()
-                .map(|dirs| dirs.cache_dir().join("lazy-pulumi").join("app.log"))
-                .unwrap_or_else(|| PathBuf::from("/tmp/lazy-pulumi.log"))
-        })
-}
+    // Set default level for unknown targets to Info
+    tui_logger::set_default_level(LevelFilter::Info);
 
-/// Initialize file-based logging
-pub fn init_file_logging() -> Result<()> {
-    // Determine log file path
-    let log_path = directories::BaseDirs::new()
-        .map(|dirs| {
-            let cache_dir = dirs.cache_dir().join("lazy-pulumi");
-            std::fs::create_dir_all(&cache_dir).ok();
-            cache_dir.join("app.log")
-        })
-        .unwrap_or_else(|| PathBuf::from("/tmp/lazy-pulumi.log"));
+    // Optionally read from RUST_LOG environment variable
+    if std::env::var("RUST_LOG").is_ok() {
+        tui_logger::set_env_filter_from_env(Some("RUST_LOG"));
+    }
 
-    // Store the path globally
-    let _ = LOG_FILE_PATH.set(log_path.clone());
-
-    // Create/truncate the log file
-    let log_file = File::create(&log_path)?;
-
-    // Set up tracing to write to file
-    let file_layer = tracing_subscriber::fmt::layer()
-        .with_writer(log_file)
-        .with_ansi(false)
-        .with_target(false);
-
-    let env_filter = tracing_subscriber::EnvFilter::from_default_env()
-        .add_directive(tracing::Level::INFO.into());
-
-    tracing_subscriber::registry()
-        .with(env_filter)
-        .with(file_layer)
-        .init();
-
-    tracing::info!("Lazy Pulumi started - logging to {:?}", log_path);
+    log::info!("Lazy Pulumi started - tui-logger initialized");
 
     Ok(())
-}
-
-/// Read the last N lines from the log file
-pub fn read_log_lines(max_lines: usize) -> Vec<String> {
-    let log_path = log_file_path();
-
-    let file = match OpenOptions::new().read(true).open(&log_path) {
-        Ok(f) => f,
-        Err(_) => return vec!["Log file not found".to_string()],
-    };
-
-    let reader = BufReader::new(file);
-    let all_lines: Vec<String> = reader.lines().filter_map(|l| l.ok()).collect();
-
-    // Return last max_lines
-    if all_lines.len() > max_lines {
-        all_lines[all_lines.len() - max_lines..].to_vec()
-    } else {
-        all_lines
-    }
-}
-
-/// Read all lines from the log file with an optional tail
-pub fn read_log_tail(tail_lines: Option<usize>) -> Vec<String> {
-    match tail_lines {
-        Some(n) => read_log_lines(n),
-        None => {
-            let log_path = log_file_path();
-            let file = match OpenOptions::new().read(true).open(&log_path) {
-                Ok(f) => f,
-                Err(_) => return vec!["Log file not found".to_string()],
-            };
-            BufReader::new(file).lines().filter_map(|l| l.ok()).collect()
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ async fn main() -> Result<()> {
     // Initialize error handling
     color_eyre::install()?;
 
-    // Initialize tracing to file (so it doesn't interfere with TUI)
-    logging::init_file_logging()?;
+    // Initialize tui-logger for in-app log viewing
+    logging::init_logging()?;
 
     // Create and run the application
     let mut app = App::new().await?;


### PR DESCRIPTION
## Summary

- Replace file-based logging with `tui-logger` crate for integrated in-app log viewing
- Add `TuiLoggerSmartWidget` with target selector and scrolling log view
- Style widget to match Dracula theme (borders, highlights, log level colors)
- Map keyboard events to `TuiWidgetEvent` for full widget interactivity

## New Log Viewer Features

- **Target filtering**: Filter logs by module/target with per-target level control
- **Dual-level control**: Separate capture vs display levels (+/- and </>)
- **Scrollback**: Page mode navigation through log history
- **Focus mode**: Isolate logs from a single target (press `f`)
- **Hide targets**: Toggle visibility of disabled targets (press `Space`)

## Key Bindings

| Key | Action |
|-----|--------|
| `h` | Toggle target selector panel visibility |
| `f` | Toggle focus on selected target only |
| `↑/↓` | Select previous/next target |
| `←/>` or `</>` | Reduce/increase SHOWN log level |
| `-/+` | Reduce/increase CAPTURED log level |
| `PageUp/Down` | Scroll through log history |
| `Space` | Hide targets with logfilter off |
| `l/Esc` | Close logs |

## Test plan

- [x] Build succeeds (`cargo build --release`)
- [ ] Press `l` to open log viewer
- [ ] Verify logs are displayed with correct colors
- [ ] Test target filtering with `h` and arrow keys
- [ ] Test focus mode with `f`
- [ ] Verify scrollback with PageUp/Down