### PR TITLE
Distribute CLAUDE.md into focused subdirectory docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,463 +1,66 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working with this repository.
 
 ## Build & Run Commands
 
 ```bash
-# Build (debug)
-cargo build
-
-# Build (release with optimizations)
-cargo build --release
-
-# Run (release mode recommended for performance)
-cargo run --release
-
-# Check for compilation errors without building
-cargo check
-
-# Run with debug logging
-RUST_LOG=debug cargo run --release
+cargo build              # Debug build
+cargo build --release    # Release build
+cargo run --release      # Run (release recommended)
+cargo check              # Check for errors
+RUST_LOG=debug cargo run --release  # With debug logging
 ```
 
-## Logging
-
-The application uses `tui-logger` for integrated in-app log viewing. Press `l` globally to open the log viewer popup.
-
-### Log Viewer Features
-- **Smart Widget**: Combined target selector (left) and log messages view (right)
-- **Target filtering**: Filter logs by module/target with real-time level control
-- **Scrollback**: Navigate through log history with page mode
-- **Log levels**: Color-coded ERROR (red), WARN (yellow), INFO (blue), DEBUG/TRACE (muted)
-
-### Log Viewer Key Bindings
-| Key | Action |
-|-----|--------|
-| `l` or `Esc` | Close logs |
-| `h` | Toggle target selector panel visibility |
-| `f` | Toggle focus on selected target only |
-| `↑` / `↓` | Select previous/next target |
-| `←` or `<` | Reduce SHOWN log level for target |
-| `→` or `>` | Increase SHOWN log level for target |
-| `-` | Reduce CAPTURED log level for target |
-| `+` or `=` | Increase CAPTURED log level for target |
-| `PageUp` | Enter page mode, scroll up in history |
-| `PageDown` | Scroll down in history (page mode only) |
-| `Space` | Toggle hiding targets with logfilter off |
-
-### Target Selector Columns
-The target selector shows two columns (EWIDT = Error, Warn, Info, Debug, Trace):
-- **Inverted letters**: Log levels shown in the messages view
-- **Normal letters**: Log levels being captured by the logger
-- If a letter is missing, that level is not captured
-
-### Implementation
-- `src/logging.rs` - tui-logger initialization using `log` crate
-- `src/ui/logs.rs` - TuiLoggerSmartWidget rendering
-- Uses `TuiWidgetState` for managing filter state and scroll position
-
-## Required Environment Variables
+## Environment Variables
 
 ```bash
-# Required: Pulumi API authentication
-export PULUMI_ACCESS_TOKEN="pul-xxxxxxxxxxxx"
-
-# Optional: Default organization
-export PULUMI_ORG="your-org-name"
-
-# Optional: Custom API endpoint (defaults to https://api.pulumi.com)
-export PULUMI_API_URL="https://api.pulumi.com"
+export PULUMI_ACCESS_TOKEN="pul-xxxxxxxxxxxx"  # Required
+export PULUMI_ORG="your-org-name"               # Optional
+export PULUMI_API_URL="https://api.pulumi.com"  # Optional
 ```
 
-## Credentials
+The token can also be stored in `.env` file (just the token, no variable name).
 
-The Pulumi access token is stored in `.env` file (just the token, no variable name):
-```
-pul-xxxxxxxxxxxx
-```
+## Documentation Map
 
-To test API calls manually:
-```bash
-# Get token from .env
-TOKEN=$(cat .env | head -1)
+This documentation is distributed across multiple CLAUDE.md files for context efficiency:
 
-# List Neo tasks for an org
-curl -s -H "Content-Type: application/json" \
-  -H "Authorization: token $TOKEN" \
-  "https://api.pulumi.com/api/preview/agents/{ORG}/tasks"
+| Location | Content |
+|----------|---------|
+| `src/CLAUDE.md` | Architecture overview, TEA pattern, app flow |
+| `src/api/CLAUDE.md` | API endpoints, pagination, request/response types |
+| `src/app/CLAUDE.md` | App core, handlers, Neo chat state, polling |
+| `src/components/CLAUDE.md` | Reusable widgets (StatefulList, TextInput, TextEditor) |
+| `src/ui/CLAUDE.md` | View rendering, dashboard, Neo chat, markdown |
 
-# Get task events
-curl -s -H "Content-Type: application/json" \
-  -H "Authorization: token $TOKEN" \
-  "https://api.pulumi.com/api/preview/agents/{ORG}/tasks/{TASK_ID}/events"
-```
+Read the relevant CLAUDE.md when working in that directory.
 
-## Neo API (Preview Agents)
-
-The Neo AI agent uses the Preview Agents API:
-- **List tasks**: `GET /api/preview/agents/{org}/tasks`
-- **Get task metadata**: `GET /api/preview/agents/{org}/tasks/{taskId}` - Returns single task details
-- **Create task**: `POST /api/preview/agents/{org}/tasks` with `{"message": {"type": "user_message", "content": "...", "timestamp": "..."}}`
-- **Get events**: `GET /api/preview/agents/{org}/tasks/{taskId}/events`
-- **Respond**: `POST /api/preview/agents/{org}/tasks/{taskId}` with `{"event": {"type": "user_message", "content": "...", "timestamp": "..."}}`
-
-Event body types in responses:
-- `user_message` - User input (has `content`)
-- `assistant_message` - Assistant response (has `content`)
-- `set_task_name` - Task name change
-- `exec_tool_call` - Tool execution (has `tool_calls`)
-- `tool_response` - Tool result (has `content` with result)
-- `user_approval_request` - Approval request
-
-## Architecture Overview
-
-This is a terminal UI (TUI) application for Pulumi Cloud built with Ratatui and Tokio. The architecture follows **The Elm Architecture (TEA)** pattern for clear separation of concerns.
-
-### Project Structure
+## Project Structure
 
 ```
 src/
-├── app/                    # Application core (TEA pattern)
-│   ├── mod.rs              # App struct, new(), run(), render() (~530 lines)
-│   ├── types.rs            # Model: Tab, FocusMode, PlatformView, AppState (~205 lines)
-│   ├── handlers.rs         # Update: All keyboard event handlers (~615 lines)
-│   ├── data.rs             # Data loading & refresh logic (~305 lines)
-│   └── neo.rs              # Neo AI agent async operations (~270 lines)
-├── api/                    # Pulumi Cloud API client
-│   ├── mod.rs              # Re-exports
-│   ├── client.rs           # HTTP client implementation
-│   └── types.rs            # API response types
-├── components/             # Reusable UI widgets
-│   ├── list.rs             # StatefulList<T>
-│   ├── input.rs            # TextInput
-│   ├── editor.rs           # TextEditor (multi-line)
-│   └── spinner.rs          # Loading spinner
-├── ui/                     # View layer (rendering)
-│   ├── dashboard.rs        # Dashboard view
-│   ├── stacks.rs           # Stacks view
-│   ├── esc.rs              # ESC environments view + editor
-│   ├── neo.rs              # Neo chat view
-│   ├── platform.rs         # Platform view
-│   ├── syntax.rs           # Syntax highlighting (syntect)
-│   └── ...                 # Other UI components
-├── config.rs               # User configuration
-├── event.rs                # Async event handler
-├── logging.rs              # tui-logger initialization
-├── startup.rs              # Startup checks
-├── theme.rs                # UI theme/colors
-├── tui.rs                  # Terminal setup/teardown
-└── main.rs                 # Entry point
+├── CLAUDE.md       # Architecture overview
+├── app/            # Application core (TEA pattern)
+│   └── CLAUDE.md   # App state, handlers, Neo polling
+├── api/            # Pulumi Cloud API client
+│   └── CLAUDE.md   # API endpoints, pagination
+├── components/     # Reusable UI widgets
+│   └── CLAUDE.md   # Widget documentation
+├── ui/             # View layer (rendering)
+│   └── CLAUDE.md   # View rendering details
+├── config.rs       # User configuration
+├── event.rs        # Async event handler (crossterm)
+├── logging.rs      # tui-logger initialization
+├── startup.rs      # Startup checks
+├── theme.rs        # UI theme/colors
+├── tui.rs          # Terminal setup/teardown
+└── main.rs         # Entry point
 ```
 
-### The Elm Architecture (TEA) Pattern
+## Quick Reference
 
-The application follows TEA principles:
-
-1. **Model** (`app/types.rs`): Pure data types defining application state
-   - `AppState` - All fetched data (stacks, environments, tasks, etc.)
-   - `Tab`, `FocusMode`, `PlatformView` - UI state enums
-   - `DataLoadResult`, `NeoAsyncResult`, `StartupCheckResult` - Async operation results
-
-2. **Update** (`app/handlers.rs`): Event handlers that modify state
-   - `handle_key()` - Main keyboard event dispatcher
-   - `handle_stacks_key()`, `handle_esc_key()`, `handle_neo_key()`, etc.
-   - Pure functions that take current state and produce new state
-
-3. **View** (`app/mod.rs` + `ui/`): Renders state to terminal
-   - `render()` method produces UI from current state
-   - `ui/` module contains view-specific rendering functions
-
-### Core Components
-
-- **App** (`src/app/mod.rs`): Central state machine managing UI state, data, and the main event loop. Contains `AppState` for data.
-
-- **Handlers** (`src/app/handlers.rs`): All keyboard event handling, organized by context (global, tab-specific, popup-specific).
-
-- **Data** (`src/app/data.rs`): Async data loading with parallel requests using tokio channels.
-
-- **Neo** (`src/app/neo.rs`): Neo AI agent operations including polling, message sending, and task management.
-
-- **API Client** (`src/api/client.rs`): Async HTTP client for Pulumi Cloud REST API. Handles authentication via bearer token and provides methods for Stacks, ESC, Neo, and Resource Search APIs.
-
-- **Event System** (`src/event.rs`): Async event handler using crossterm. Generates tick events for animations and captures keyboard/mouse input.
-
-- **TUI** (`src/tui.rs`): Terminal setup/teardown with crossterm backend. Handles raw mode and alternate screen.
-
-### UI Layer
-
-Views in `src/ui/` render to Ratatui frames:
-- `dashboard.rs` - Overview with stats widgets
-- `stacks.rs` - Stack list and update history
-- `esc.rs` - ESC environments with YAML/resolved values
-- `neo.rs` - Chat interface for Pulumi's AI agent
-- `platform.rs` - Services, Components, Templates views
-- `header.rs` - Tab bar with organization display
-- `help.rs` - Keyboard shortcut overlay
-
-### Reusable Components (`src/components/`)
-
-- `StatefulList<T>` - Scrollable list with selection state
-- `TextInput` - Single-line text input with cursor
-- `TextEditor` - Multi-line text editor with cursor, scrolling, and syntax highlighting
-- `Spinner` - Animated loading indicator
-
-### Application Flow
-
-1. `main.rs` initializes color-eyre, tui-logger, creates `App`, and calls `app.run()`
-2. `App::new()` sets up terminal, event handler, API client, loads initial data
-3. `App::run()` enters async loop: render frame → poll events → handle input
-4. `handlers.rs` dispatches to tab-specific handlers (`handle_stacks_key`, `handle_esc_key`, `handle_neo_key`)
-5. API calls are async and set `is_loading` flag during requests
-
-### State Management
-
-- `FocusMode::Normal` vs `FocusMode::Input` controls whether keys go to navigation or text input
-- Popup states (`show_help`, `show_org_selector`, `error`) overlay the main content
-- Each view has a `StatefulList` for selection tracking
-
-### Startup Checks (Async)
-
-Startup checks run asynchronously to keep the UI responsive:
-- **Implementation**: `spawn_startup_checks()` in `handlers.rs` spawns background tasks
-- **Communication**: Uses `StartupCheckResult` enum and tokio channel (`startup_result_tx/rx`)
-- **Processing**: `process_startup_results()` receives results non-blocking in main loop
-- **Benefits**: Spinner animates during CLI version check instead of UI freezing
-- **Checks performed**:
-  - `PULUMI_ACCESS_TOKEN` environment variable (synchronous but wrapped in task)
-  - Pulumi CLI availability via `pulumi version` (async)
-
-## Neo Chat Implementation
-
-### Polling Mechanism
-The Neo chat uses async polling to fetch agent responses:
-- **Active polling** (after sending message): Every 500ms (5 ticks at 100ms tick rate)
-- **Background polling** (when viewing Neo tab): Every 3 seconds (30 ticks)
-- **Immediate poll**: Triggered right after task creation
-- **Task status aware**: Polls fetch both events AND task status in parallel
-- **Stop conditions** for active polling:
-  - Task status is NOT "running"/"in_progress"/"pending" AND has assistant response
-  - OR max 60 polls (~30 seconds timeout)
-  - OR 20+ stable polls AND task is not running (fallback)
-- **Thinking indicator**: Stays visible as long as task status is "running"
-
-### Key State Variables (in `App`)
-- `neo_polling: bool` - Whether actively polling for responses (fast polling after sending)
-- `neo_poll_counter: u8` - Ticks since last poll
-- `neo_stable_polls: u8` - Consecutive polls with no new messages
-- `neo_bg_poll_counter: u8` - Background poll counter when Neo tab is active
-- `neo_scroll_state: ScrollViewState` - Scroll state from tui-scrollview crate
-- `neo_auto_scroll: Arc<AtomicBool>` - Thread-safe auto-scroll toggle
-- `neo_task_is_running: bool` - Tracks if current task status is "running" (from API)
-
-### Scrolling Implementation (using tui-scrollview)
-Uses `tui-scrollview` crate for proper scroll handling (similar to Tenere LLM TUI):
-- `ScrollViewState` manages scroll position with proper `scroll_to_bottom()` method
-- `Arc<AtomicBool>` for thread-safe auto-scroll toggle (pattern from Tenere)
-- Auto-scroll enabled by default, disabled when user scrolls up manually
-- Re-enabled when user presses `G` or new messages arrive with auto-scroll on
-
-Key methods used:
-- `scroll_state.scroll_up()` / `scroll_down()` - Single line movement
-- `scroll_state.scroll_page_up()` / `scroll_page_down()` - Page movement
-- `scroll_state.scroll_to_top()` / `scroll_to_bottom()` - Jump to edges
-- `scroll_state.offset()` - Get current scroll position for scrollbar
-
-### Thinking Indicator
-- Dedicated 2-line area shown between chat and input
-- Visible when: `neo_polling || is_loading || neo_task_is_running`
-- `neo_task_is_running` ensures banner stays visible until API confirms task is no longer running
-- Displays animated spinner with "Neo is thinking..." message
-- Centered with background highlight for visibility
-
-### Markdown Rendering
-Assistant messages support markdown rendering:
-- **Bold** (`**text**` or `__text__`)
-- *Italic* (`*text*` or `_text_`)
-- `Inline code` (backticks)
-- Code blocks with language labels (triple backticks)
-- Headers (`#`, `##`, `###`)
-- Bullet lists (`-` or `*`)
-- Numbered lists (`1.`, `2.`, etc.)
-
-### Neo Tab Key Bindings
-| Key | Action |
-|-----|--------|
-| `i` | Enter input mode to type message |
-| `n` | Start new task/conversation |
-| `d` | Show task details dialog (only in full-width chat mode) |
-| `↑`/`↓` | Navigate task list (left panel) |
-| `j` | Scroll chat down 3 lines (newer) |
-| `k` | Scroll chat up 3 lines (older) + disable auto-scroll |
-| `J`/`PageDown` | Scroll chat down by page |
-| `K`/`PageUp` | Scroll chat up by page + disable auto-scroll |
-| `g` | Jump to top (oldest messages) + disable auto-scroll |
-| `G` | Jump to bottom + re-enable auto-scroll |
-| `Enter` | Load selected task's messages |
-| `Esc` | Show task list (exit full-width chat mode) |
-
-### Task Details Dialog
-Press `d` in full-width chat mode to show task details (similar to Pulumi Cloud web UI):
-- **Status**: Task state (idle, running, completed, failed)
-- **Started on**: Task creation timestamp
-- **Started by**: User who initiated the task
-- **Linked PRs**: Associated pull requests with state (open/merged/closed)
-- **Involved entities**: Stacks, environments, repositories linked to task
-- **Active policies**: Policy groups enforcing guardrails
-
-The dialog fetches fresh data from `GET /api/preview/agents/{org}/tasks/{taskId}` each time it opens.
-
-### Task Data Types
-```rust
-NeoTask {
-    id, name, status, created_at, updated_at, url,
-    started_by: Option<NeoTaskUser>,
-    linked_prs: Vec<NeoLinkedPR>,
-    entities: Vec<NeoEntity>,
-    policies: Vec<NeoPolicy>,
-}
-```
-
-Note: API may return `null` for array fields. Use custom deserializer `null_to_empty_vec` to handle this.
-
-### Message Types (`NeoMessageType`)
-- `UserMessage` - User input
-- `AssistantMessage` - Neo's response (may include tool_calls, rendered with markdown)
-- `ToolCall` - Tool execution notification
-- `ToolResponse` - Tool result (truncated display)
-- `ApprovalRequest` - Requires user approval
-- `TaskNameChange` - Task renamed by agent
-
-## API Pagination Notes
-
-All list APIs require pagination to get accurate counts. Key details:
-
-### ESC Environments API
-- **List Endpoint**: `GET /api/esc/environments/{org}`
-- **Pagination**: Uses `continuationToken` query parameter
-- **Response fields**: `environments` array, no `organization` field in each item (implied from URL)
-- **Field names**: Uses `created` and `modified` (NOT `createdAt`/`modifiedAt`)
-- **Extra fields**: API returns additional fields like `id`, `tags`, `links`, `referrerMetadata`, `settings` - use `#[serde(default)]` to ignore
-
-### ESC Environment Details API
-- **Get Definition**: `GET /api/esc/environments/{org}/{project}/{environment}`
-  - Returns YAML content directly as plain text (not JSON)
-- **Update Definition**: `PATCH /api/esc/environments/{org}/{project}/{environment}`
-  - Request body: YAML content as plain text
-  - Content-Type: `application/x-yaml`
-  - Returns updated environment metadata on success
-- **Open Environment** (two-step process):
-  1. `POST /api/esc/environments/{org}/{project}/{environment}/open` - Returns `{"id": 1234567, "diagnostics": ""}`
-  2. `GET /api/esc/environments/{org}/{project}/{environment}/open/{sessionId}` - Returns resolved values as JSON
-- **Note**: Opening an environment may return 400 errors with diagnostics if the environment has invalid references (e.g., `values.stackRefs` referencing a non-existent stack)
-
-### Neo Tasks API
-- **Endpoint**: `GET /api/preview/agents/{org}/tasks`
-- **Pagination**: Uses `pageSize` (default 100, max 1000) and `continuationToken`
-- **Response**: `{ tasks: [...], continuationToken: "..." }`
-
-### Resource Search API
-- **Endpoint**: `GET /api/orgs/{org}/search/resourcesv2` (note: v2 endpoint)
-- **Pagination**: Uses `page` (1-based) and `size` parameters
-- **Response**: Includes `pagination.next` URL when more results available
-- **Note**: Old endpoint `/api/orgs/{org}/search/resources` is deprecated
-
-### Stacks API
-- **Endpoint**: `GET /api/user/stacks?organization={org}`
-- **Pagination**: Uses `continuationToken`
-- **Response**: `{ stacks: [...], continuationToken: "..." }`
-
-### Recent Stack Updates API (Console)
-- **Endpoint**: `GET /api/console/orgs/{org}/stacks/updates/recent?limit=N`
-- **Returns**: Array of stacks with their `lastUpdate` containing `requestedBy`, `info`, `version`
-- **Used for**: Dashboard "Recent Stack Updates" panel
-
-### Resource Summary API
-- **Endpoint**: `GET /api/orgs/{org}/resources/summary?granularity=daily&lookbackDays=N`
-- **Returns**: `{ summary: [{ year, month, day, resources, resourceHours }, ...] }`
-- **Used for**: Dashboard "Resource Count Over Time" chart
-
-## Dashboard Features
-
-The dashboard displays:
-
-1. **Stats Cards** (top row):
-   - Stacks count
-   - Environments count
-   - Neo Tasks count
-   - Resources count
-   - Uses `tui-big-text` crate with `PixelSize::Quadrant` for large, centered numbers
-
-2. **Resource Count Over Time** (full-width chart):
-   - Uses ratatui `Chart` widget with `GraphType::Line` and `Marker::Braille`
-   - Shows resource count over the last 30 days
-   - X-axis: date labels (first and last date)
-   - Y-axis: resource count with auto-calculated bounds
-   - Data from `/api/orgs/{org}/resources/summary` API
-
-3. **Recent Stack Updates** (bottom left):
-   - Shows last 5 unique stack updates (deduplicated by project/stack)
-   - Format: `project / stack / Update #N` + `username updated X ago`
-   - Data from `/api/console/orgs/{org}/stacks/updates/recent` API
-
-4. **Quick Info** (bottom right):
-   - Keyboard shortcuts: Tab (views), ? (help), r (refresh)
-
-## ESC Environment Editor
-
-The ESC view includes a built-in YAML editor for modifying environment definitions.
-
-### Opening the Editor
-- Navigate to the ESC tab and select an environment
-- Press `e` to open the editor dialog
-- The editor loads the environment's YAML definition
-
-### Editor Features
-- **Syntax highlighting**: YAML syntax coloring using syntect
-- **Line numbers**: Displayed in the left gutter
-- **Scrolling**: Vertical scrollbar for long documents
-- **Cursor positioning**: Visual cursor with line/column tracking
-- **Modified indicator**: Title shows `[modified]` when changes are pending
-
-### Editor Key Bindings
-| Key | Action |
-|-----|--------|
-| `Esc` | Save changes and close editor |
-| `Ctrl+C` | Cancel and close without saving |
-| `↑`/`↓`/`←`/`→` | Move cursor |
-| `Home` | Move to beginning of line |
-| `End` | Move to end of line |
-| `PageUp`/`PageDown` | Scroll by page |
-| `Ctrl+Home` | Jump to top of document |
-| `Ctrl+End` | Jump to end of document |
-| `Tab` | Insert 2-space indentation |
-| `Enter` | Insert newline with auto-indent |
-| `Backspace` | Delete character before cursor |
-| `Delete` | Delete character at cursor |
-| `Ctrl+U` | Delete to beginning of line |
-| `Ctrl+K` | Delete to end of line |
-| `Ctrl+A` | Move to beginning of line |
-| `Ctrl+E` | Move to end of line |
-| `Ctrl+D` | Delete character at cursor |
-
-### Implementation Details
-- **Component**: `src/components/editor.rs` - `TextEditor` struct
-- **Rendering**: `src/ui/esc.rs` - `render_esc_editor()` function
-- **API**: `PATCH /api/esc/environments/{org}/{project}/{environment}` with YAML body
-
-## Ratatui LLM Chat Best Practices
-
-When building LLM chat interfaces with Ratatui:
-
-1. **Use tui-scrollview** for scrolling: Manual scroll calculation with `Paragraph::scroll()` doesn't handle wrapped lines correctly. The `tui-scrollview` crate provides proper `ScrollViewState` with `scroll_to_bottom()`.
-
-2. **Auto-scroll pattern**: Use `Arc<AtomicBool>` for thread-safe auto-scroll toggle (pattern from Tenere). Enable on send/receive, disable on manual scroll up, re-enable on scroll to bottom.
-
-3. **Thinking indicator**: Use a dedicated layout area (not inline with messages) for loading/thinking state. This ensures visibility regardless of scroll position.
-
-4. **Background polling**: When tab is active, poll periodically (every few seconds) to catch updates without requiring manual refresh.
-
-5. **Reference implementations**:
-   - [Tenere](https://github.com/pythops/tenere) - LLM TUI with auto-scroll, streaming
-   - [Oatmeal](https://github.com/dustinblackman/oatmeal) - LLM chat with multiple backends
-   - [tui-scrollview](https://github.com/joshka/tui-scrollview) - ScrollView widget for Ratatui
+- **TEA Pattern**: Model (types.rs) → Update (handlers.rs) → View (ui/)
+- **State**: `FocusMode::Normal` vs `FocusMode::Input` for navigation vs text input
+- **Async**: Uses tokio channels for background operations
+- **Logging**: Press `l` globally to open log viewer (tui-logger)

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,53 @@
+# src/ - Architecture Overview
+
+Terminal UI application for Pulumi Cloud built with Ratatui and Tokio.
+
+**Related docs**: See `../CLAUDE.md` for build commands. Subdirectory docs: `app/CLAUDE.md`, `api/CLAUDE.md`, `components/CLAUDE.md`, `ui/CLAUDE.md`
+
+## The Elm Architecture (TEA) Pattern
+
+1. **Model** (`app/types.rs`): Pure data types defining application state
+2. **Update** (`app/handlers.rs`): Event handlers that modify state
+3. **View** (`app/mod.rs` + `ui/`): Renders state to terminal
+
+## Application Flow
+
+1. `main.rs` initializes color-eyre, tui-logger, creates `App`, calls `app.run()`
+2. `App::new()` sets up terminal, event handler, API client, loads initial data
+3. `App::run()` enters async loop: render → poll events → handle input
+4. `handlers.rs` dispatches to tab-specific handlers
+5. API calls are async and set `is_loading` flag during requests
+
+## State Management
+
+- `FocusMode::Normal` vs `FocusMode::Input` controls navigation vs text input
+- Popup states (`show_help`, `show_org_selector`, `error`) overlay main content
+- Each view has a `StatefulList` for selection tracking
+
+## Key Modules
+
+| File | Purpose |
+|------|---------|
+| `main.rs` | Entry point, initializes app |
+| `tui.rs` | Terminal setup/teardown (crossterm backend) |
+| `event.rs` | Async event handler, tick events for animations |
+| `config.rs` | User configuration |
+| `theme.rs` | UI colors and styles |
+| `logging.rs` | tui-logger initialization |
+| `startup.rs` | Startup validation checks |
+
+## Startup Checks (Async)
+
+Startup checks run asynchronously to keep UI responsive:
+- `spawn_startup_checks()` in `handlers.rs` spawns background tasks
+- Uses `StartupCheckResult` enum and tokio channel
+- Checks: `PULUMI_ACCESS_TOKEN` env var, Pulumi CLI availability
+
+## Logging
+
+Press `l` globally to open log viewer. Key bindings:
+- `h`: Toggle target selector
+- `f`: Focus on selected target
+- `↑/↓`: Select target
+- `←/→`: Change shown log level
+- `PageUp/PageDown`: Scroll history

--- a/src/api/CLAUDE.md
+++ b/src/api/CLAUDE.md
@@ -1,0 +1,56 @@
+# src/api/ - Pulumi Cloud API Client
+
+Async HTTP client for Pulumi Cloud REST API using reqwest.
+
+**Related docs**: `../CLAUDE.md` (architecture), `../app/CLAUDE.md` (data loading), `../../CLAUDE.md` (env vars)
+
+## Files
+
+- `client.rs` - HTTP client implementation with bearer token auth
+- `types.rs` - API response/request types (serde)
+- `mod.rs` - Re-exports
+
+## API Endpoints
+
+### Stacks
+- `GET /api/user/stacks?organization={org}` - List stacks
+- Pagination: `continuationToken` query param
+
+### ESC Environments
+- `GET /api/esc/environments/{org}` - List environments
+- `GET /api/esc/environments/{org}/{project}/{env}` - Get YAML definition (plain text)
+- `PATCH /api/esc/environments/{org}/{project}/{env}` - Update YAML (Content-Type: `application/x-yaml`)
+- `POST /api/esc/environments/{org}/{project}/{env}/open` - Open session (returns `{id, diagnostics}`)
+- `GET /api/esc/environments/{org}/{project}/{env}/open/{sessionId}` - Get resolved values
+
+Field names: uses `created`/`modified` (NOT `createdAt`/`modifiedAt`)
+
+### Neo (Preview Agents)
+- `GET /api/preview/agents/{org}/tasks` - List tasks (pageSize, continuationToken)
+- `GET /api/preview/agents/{org}/tasks/{taskId}` - Get task metadata
+- `POST /api/preview/agents/{org}/tasks` - Create task
+- `GET /api/preview/agents/{org}/tasks/{taskId}/events` - Get events
+- `POST /api/preview/agents/{org}/tasks/{taskId}` - Send message
+
+Event body types: `user_message`, `assistant_message`, `set_task_name`, `exec_tool_call`, `tool_response`, `user_approval_request`
+
+### Resource Search
+- `GET /api/orgs/{org}/search/resourcesv2` - Search resources (v2 endpoint)
+- Pagination: `page` (1-based), `size` params
+
+### Dashboard Data
+- `GET /api/console/orgs/{org}/stacks/updates/recent?limit=N` - Recent updates
+- `GET /api/orgs/{org}/resources/summary?granularity=daily&lookbackDays=N` - Resource chart
+
+## Testing API Manually
+
+```bash
+TOKEN=$(cat .env | head -1)
+curl -s -H "Authorization: token $TOKEN" \
+  "https://api.pulumi.com/api/preview/agents/{ORG}/tasks"
+```
+
+## Serde Notes
+
+- API may return `null` for array fields - use `null_to_empty_vec` deserializer
+- Extra fields from API - use `#[serde(default)]` to ignore

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -1,0 +1,80 @@
+# src/app/ - Application Core (TEA Pattern)
+
+Central state machine managing UI state, data, and event loop.
+
+**Related docs**: `../CLAUDE.md` (architecture), `../api/CLAUDE.md` (API calls), `../ui/CLAUDE.md` (rendering), `../components/CLAUDE.md` (widgets)
+
+## Files
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `mod.rs` | ~530 | App struct, new(), run(), render() |
+| `types.rs` | ~205 | Model: Tab, FocusMode, AppState |
+| `handlers.rs` | ~615 | Update: All keyboard event handlers |
+| `data.rs` | ~305 | Data loading & refresh logic |
+| `neo.rs` | ~270 | Neo AI agent async operations |
+
+## TEA Implementation
+
+- **Model** (`types.rs`): `AppState`, `Tab`, `FocusMode`, `PlatformView`, async result enums
+- **Update** (`handlers.rs`): `handle_key()` dispatches to tab-specific handlers
+- **View** (`mod.rs`): `render()` method produces UI from state
+
+## Key Types
+
+```rust
+enum Tab { Dashboard, Stacks, Esc, Neo, Platform }
+enum FocusMode { Normal, Input }
+struct AppState { stacks, environments, neo_tasks, resources, ... }
+```
+
+## Event Handlers (handlers.rs)
+
+- `handle_key()` - Main dispatcher
+- `handle_stacks_key()` - Stacks tab navigation
+- `handle_esc_key()` - ESC environments
+- `handle_neo_key()` - Neo chat (see below)
+- `handle_platform_key()` - Platform view
+
+## Neo Chat State Variables
+
+| Variable | Type | Purpose |
+|----------|------|---------|
+| `neo_polling` | bool | Active polling after sending message |
+| `neo_poll_counter` | u8 | Ticks since last poll |
+| `neo_stable_polls` | u8 | Consecutive polls with no new messages |
+| `neo_bg_poll_counter` | u8 | Background poll counter |
+| `neo_scroll_state` | ScrollViewState | Scroll position (tui-scrollview) |
+| `neo_auto_scroll` | Arc<AtomicBool> | Thread-safe auto-scroll toggle |
+| `neo_task_is_running` | bool | Task status is "running" |
+
+## Neo Polling Mechanism
+
+- **Active polling**: Every 500ms (5 ticks) after sending
+- **Background polling**: Every 3s (30 ticks) when Neo tab active
+- **Stop conditions**: Task not running + has assistant response, or timeout
+
+## Neo Key Bindings
+
+| Key | Action |
+|-----|--------|
+| `i` | Enter input mode |
+| `n` | New task |
+| `d` | Task details dialog |
+| `j/k` | Scroll 3 lines |
+| `J/K` | Page scroll |
+| `g/G` | Jump to top/bottom |
+| `Enter` | Load selected task |
+| `Esc` | Show task list |
+
+## Data Loading (data.rs)
+
+Uses tokio channels for parallel async requests. Sets `is_loading` flag during requests.
+
+## Startup Checks
+
+`spawn_startup_checks()` spawns background tasks for:
+- `PULUMI_ACCESS_TOKEN` validation
+- Pulumi CLI availability (`pulumi version`)
+
+Uses `StartupCheckResult` enum and tokio channel.

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -1,0 +1,71 @@
+# src/components/ - Reusable UI Widgets
+
+Generic widgets used across multiple views.
+
+**Related docs**: `../ui/CLAUDE.md` (view rendering), `../app/CLAUDE.md` (state management)
+
+## Files
+
+| File | Widget | Purpose |
+|------|--------|---------|
+| `list.rs` | `StatefulList<T>` | Scrollable list with selection |
+| `input.rs` | `TextInput` | Single-line text input with cursor |
+| `editor.rs` | `TextEditor` | Multi-line editor with syntax highlighting |
+| `spinner.rs` | `Spinner` | Animated loading indicator |
+
+## StatefulList<T>
+
+Scrollable list with selection tracking.
+
+```rust
+let mut list = StatefulList::with_items(vec![...]);
+list.next();     // Select next item
+list.previous(); // Select previous item
+list.selected(); // Get selected item
+```
+
+## TextInput
+
+Single-line input with cursor positioning.
+
+```rust
+let mut input = TextInput::new();
+input.insert('a');
+input.backspace();
+input.value();   // Get current text
+input.cursor();  // Get cursor position
+```
+
+## TextEditor
+
+Multi-line editor for ESC environment YAML editing.
+
+Features:
+- Syntax highlighting (syntect)
+- Line numbers in gutter
+- Vertical scrolling
+- Cursor line/column tracking
+- Auto-indent on Enter
+
+Key bindings:
+| Key | Action |
+|-----|--------|
+| `Esc` | Save and close |
+| `Ctrl+C` | Cancel without saving |
+| Arrow keys | Move cursor |
+| `Home/End` | Line start/end |
+| `Ctrl+Home/End` | Document start/end |
+| `Tab` | Insert 2 spaces |
+| `Ctrl+U/K` | Delete to line start/end |
+| `Ctrl+A/E` | Line start/end (Emacs) |
+
+## Spinner
+
+Animated loading indicator using braille characters.
+
+```rust
+let spinner = Spinner::new();
+spinner.frame(); // Returns current animation frame
+```
+
+Used in: Loading states, Neo "thinking" indicator

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -1,0 +1,74 @@
+# src/ui/ - View Layer
+
+Renders application state to Ratatui frames.
+
+**Related docs**: `../app/CLAUDE.md` (state & handlers), `../components/CLAUDE.md` (widgets), `../api/CLAUDE.md` (data types)
+
+## Files
+
+| File | View | Description |
+|------|------|-------------|
+| `dashboard.rs` | Dashboard | Stats cards, resource chart, recent updates |
+| `stacks.rs` | Stacks | Stack list and update history |
+| `esc.rs` | ESC | Environments list, YAML editor |
+| `neo.rs` | Neo | Chat interface with markdown rendering |
+| `platform.rs` | Platform | Services, Components, Templates |
+| `header.rs` | Header | Tab bar with organization display |
+| `help.rs` | Help | Keyboard shortcut overlay |
+| `logs.rs` | Logs | tui-logger widget |
+| `splash.rs` | Splash | Startup loading screen |
+| `markdown.rs` | - | Markdown parsing for Neo messages |
+| `syntax.rs` | - | Syntax highlighting (syntect) |
+
+## Dashboard Features
+
+1. **Stats Cards** (top row): Stacks, Environments, Tasks, Resources
+   - Uses `tui-big-text` with `PixelSize::Quadrant`
+
+2. **Resource Chart** (full-width): Line chart over 30 days
+   - `Chart` widget with `GraphType::Line`, `Marker::Braille`
+
+3. **Recent Updates** (bottom left): Last 5 unique stack updates
+4. **Quick Info** (bottom right): Keyboard shortcuts
+
+## ESC Editor
+
+`render_esc_editor()` renders the YAML editor dialog:
+- Line numbers in gutter
+- Syntax highlighting via syntect
+- Vertical scrollbar
+- `[modified]` indicator in title
+
+## Neo Chat Rendering
+
+Uses `tui-scrollview` for proper scroll handling.
+
+### Markdown Support
+- **Bold**: `**text**` or `__text__`
+- *Italic*: `*text*` or `_text_`
+- `Inline code`: backticks
+- Code blocks: triple backticks with language labels
+- Headers: `#`, `##`, `###`
+- Lists: `-`, `*`, `1.`, `2.`
+
+### Thinking Indicator
+Dedicated 2-line area between chat and input:
+- Visible when: `neo_polling || is_loading || neo_task_is_running`
+- Animated spinner with "Neo is thinking..."
+
+### Message Types
+- `UserMessage` - User input
+- `AssistantMessage` - Neo response (markdown rendered)
+- `ToolCall` - Tool execution notification
+- `ToolResponse` - Tool result (truncated)
+- `ApprovalRequest` - Requires user approval
+- `TaskNameChange` - Task renamed
+
+## Ratatui LLM Chat Best Practices
+
+1. **Use tui-scrollview**: `Paragraph::scroll()` doesn't handle wrapped lines
+2. **Auto-scroll**: `Arc<AtomicBool>` for thread-safe toggle
+3. **Thinking indicator**: Dedicated layout area, not inline
+4. **Background polling**: Poll every few seconds when tab active
+
+Reference: [Tenere](https://github.com/pythops/tenere), [tui-scrollview](https://github.com/joshka/tui-scrollview)


### PR DESCRIPTION
## Summary

- Split large root CLAUDE.md (464 lines) into smaller, context-efficient files
- Each subdirectory now has its own CLAUDE.md loaded only when working there
- All files cross-linked with "Related docs" sections for navigation
- Reduces context window usage when working on specific subsystems

## Documentation Map

| Location | Content |
|----------|---------|
| `CLAUDE.md` (root) | Build commands, env vars, documentation map |
| `src/CLAUDE.md` | Architecture overview, TEA pattern, app flow |
| `src/api/CLAUDE.md` | API endpoints, pagination, serde notes |
| `src/app/CLAUDE.md` | App core, handlers, Neo chat state, polling |
| `src/components/CLAUDE.md` | Widget documentation |
| `src/ui/CLAUDE.md` | View rendering, dashboard, Neo chat, markdown |

## Test plan

- [x] Build passes (`cargo check`)
- [x] All CLAUDE.md files created and cross-linked