### PR TITLE
Add Commands tab for Pulumi CLI execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ src/
 │   └── CLAUDE.md   # App state, handlers, Neo polling
 ├── api/            # Pulumi Cloud API client
 │   └── CLAUDE.md   # API endpoints, pagination
+├── commands/       # Pulumi CLI command execution
+│   ├── mod.rs      # Module exports
+│   ├── types.rs    # Command definitions, categories, parameters
+│   └── executor.rs # PTY-based command execution
 ├── components/     # Reusable UI widgets
 │   └── CLAUDE.md   # Widget documentation
 ├── ui/             # View layer (rendering)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,12 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -388,7 +394,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -512,6 +518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +627,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1077,6 +1100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1179,7 @@ dependencies = [
  "image",
  "log",
  "once_cell",
+ "portable-pty",
  "ratatui",
  "reqwest",
  "serde",
@@ -1194,7 +1227,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1266,6 +1299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1344,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
 
 [[package]]
 name = "nom"
@@ -1389,7 +1445,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1482,11 +1538,32 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -1664,7 +1741,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1755,7 +1832,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1874,7 +1951,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1999,6 +2076,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2125,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -2176,6 +2311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,7 +2466,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -2959,6 +3103,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ chrono = { version = "0.4", features = ["serde"] }
 directories = "5"
 urlencoding = "2"
 
+# PTY for proper terminal emulation (streaming CLI output)
+portable-pty = "0.8"
+
 # Syntax Highlighting
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
 once_cell = "1"

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -23,7 +23,7 @@ Central state machine managing UI state, data, and event loop.
 ## Key Types
 
 ```rust
-enum Tab { Dashboard, Stacks, Esc, Neo, Platform }
+enum Tab { Dashboard, Commands, Neo, Stacks, Esc, Platform }
 enum FocusMode { Normal, Input }
 struct AppState { stacks, environments, neo_tasks, resources, ... }
 ```
@@ -35,6 +35,7 @@ struct AppState { stacks, environments, neo_tasks, resources, ... }
 - `handle_esc_key()` - ESC environments
 - `handle_neo_key()` - Neo chat (see below)
 - `handle_platform_key()` - Platform view
+- `handle_commands_key()` - Commands tab (see below)
 
 ## Neo Chat State Variables
 
@@ -78,3 +79,31 @@ Uses tokio channels for parallel async requests. Sets `is_loading` flag during r
 - Pulumi CLI availability (`pulumi version`)
 
 Uses `StartupCheckResult` enum and tokio channel.
+
+## Commands Tab
+
+Executes Pulumi CLI commands with streaming output via PTY.
+
+### View States (`CommandsViewState`)
+- `BrowsingCategories` - Navigating command categories
+- `BrowsingCommands` - Navigating commands in selected category
+- `InputDialog` - Filling command parameters
+- `ConfirmDialog` - Confirming destructive commands
+- `OutputView` - Viewing command output
+
+### Key Bindings
+| Key | Context | Action |
+|-----|---------|--------|
+| `↑/↓` | Categories/Commands | Navigate |
+| `→/Enter` | Categories | Enter commands list |
+| `←` | Commands | Back to categories |
+| `Enter` | Commands | Run selected command |
+| `Tab` | InputDialog | Next parameter |
+| `y/n` | ConfirmDialog | Confirm/cancel |
+| `j/k` | OutputView | Scroll 3 lines |
+| `g/G` | OutputView | Top/bottom |
+| `Esc` | OutputView | Close |
+
+### PTY Execution
+Commands run in pseudo-TTY via `portable-pty` crate for proper streaming output.
+Deduplication filters repeated progress lines from Pulumi output.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -62,12 +62,13 @@ pub enum Tab {
     Esc,
     Neo,
     Platform,
+    Commands,
 }
 
 impl Tab {
     pub fn all() -> &'static [Tab] {
-        // Neo is second after Dashboard
-        &[Tab::Dashboard, Tab::Neo, Tab::Stacks, Tab::Esc, Tab::Platform]
+        // Dashboard, Commands, Neo, then the rest
+        &[Tab::Dashboard, Tab::Commands, Tab::Neo, Tab::Stacks, Tab::Esc, Tab::Platform]
     }
 
     pub fn title(&self) -> &'static str {
@@ -77,26 +78,29 @@ impl Tab {
             Tab::Esc => " Environment ",
             Tab::Neo => " Neo ",
             Tab::Platform => " Platform ",
+            Tab::Commands => " Commands ",
         }
     }
 
     pub fn index(&self) -> usize {
         match self {
             Tab::Dashboard => 0,
-            Tab::Neo => 1,
-            Tab::Stacks => 2,
-            Tab::Esc => 3,
-            Tab::Platform => 4,
+            Tab::Commands => 1,
+            Tab::Neo => 2,
+            Tab::Stacks => 3,
+            Tab::Esc => 4,
+            Tab::Platform => 5,
         }
     }
 
     pub fn from_index(index: usize) -> Self {
         match index {
             0 => Tab::Dashboard,
-            1 => Tab::Neo,
-            2 => Tab::Stacks,
-            3 => Tab::Esc,
-            4 => Tab::Platform,
+            1 => Tab::Commands,
+            2 => Tab::Neo,
+            3 => Tab::Stacks,
+            4 => Tab::Esc,
+            5 => Tab::Platform,
             _ => Tab::Dashboard,
         }
     }

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -1,0 +1,361 @@
+//! Command executor for running Pulumi CLI commands
+//!
+//! Handles running commands as subprocesses with streaming output.
+//! Uses a pseudo-TTY (PTY) to make Pulumi output properly stream.
+
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::io::{BufRead, BufReader};
+use std::sync::mpsc as std_mpsc;
+use std::thread;
+use tokio::sync::mpsc;
+
+use super::types::{CommandExecution, CommandExecutionState, OutputLine};
+
+/// Result from command execution
+#[derive(Debug)]
+pub enum CommandResult {
+    /// New output line received
+    OutputLine(OutputLine),
+    /// Command completed
+    Completed { exit_code: i32 },
+    /// Command failed to start
+    Failed(String),
+}
+
+/// Start executing a command and stream output using PTY
+pub fn spawn_command(execution: &CommandExecution, tx: mpsc::Sender<CommandResult>) {
+    let args = execution.build_args();
+    let display = execution.display_with_params();
+    let cwd = execution.get_working_directory();
+
+    // Clone values for the spawned thread
+    let args_clone = args.clone();
+    let cwd_clone = cwd.clone();
+
+    tokio::spawn(async move {
+        log::info!("Executing via PTY: {}", display);
+        if let Some(ref dir) = cwd_clone {
+            log::info!("Working directory: {}", dir);
+        }
+
+        // Use a blocking thread for PTY operations since portable-pty is sync
+        let (sync_tx, sync_rx) = std_mpsc::channel::<CommandResult>();
+
+        let pty_thread = thread::spawn(move || {
+            // Create PTY system
+            let pty_system = native_pty_system();
+
+            // Create a PTY pair with reasonable size
+            let pair = match pty_system.openpty(PtySize {
+                rows: 50,
+                cols: 200,
+                pixel_width: 0,
+                pixel_height: 0,
+            }) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    let _ = sync_tx.send(CommandResult::Failed(format!(
+                        "Failed to create PTY: {}",
+                        e
+                    )));
+                    return;
+                }
+            };
+
+            // Build command
+            let mut cmd = CommandBuilder::new("pulumi");
+            for arg in &args_clone {
+                cmd.arg(arg);
+            }
+
+            // Set working directory if specified
+            if let Some(ref dir) = cwd_clone {
+                cmd.cwd(dir);
+            }
+
+            // Set environment variables
+            cmd.env("PULUMI_SKIP_UPDATE_CHECK", "true");
+            // Don't set PULUMI_NON_INTERACTIVE - we want TTY behavior
+            // Use raw output mode to get machine-readable output
+            cmd.env("PULUMI_COLOR", "never");
+            cmd.env("PYTHONUNBUFFERED", "1");
+            cmd.env("TERM", "xterm-256color");
+
+            // Spawn the child process in the PTY
+            let mut child = match pair.slave.spawn_command(cmd) {
+                Ok(child) => child,
+                Err(e) => {
+                    let _ = sync_tx.send(CommandResult::Failed(format!(
+                        "Failed to spawn command: {}",
+                        e
+                    )));
+                    return;
+                }
+            };
+
+            // Drop the slave side - we only need the master for reading
+            drop(pair.slave);
+
+            // Get a reader for the master side
+            let reader = match pair.master.try_clone_reader() {
+                Ok(reader) => reader,
+                Err(e) => {
+                    let _ = sync_tx.send(CommandResult::Failed(format!(
+                        "Failed to get PTY reader: {}",
+                        e
+                    )));
+                    return;
+                }
+            };
+
+            // Read output in a separate thread
+            let sync_tx_reader = sync_tx.clone();
+            let reader_thread = thread::spawn(move || {
+                let buf_reader = BufReader::new(reader);
+                let mut last_line: Option<String> = None;
+
+                for line in buf_reader.lines() {
+                    match line {
+                        Ok(text) => {
+                            // Filter out ANSI escape sequences and control characters
+                            let clean_text = strip_ansi_codes(&text);
+
+                            // Skip empty lines and duplicate consecutive lines
+                            if clean_text.is_empty() {
+                                continue;
+                            }
+
+                            // Skip if this is the same as the last line (progress updates)
+                            if let Some(ref last) = last_line {
+                                if is_duplicate_progress_line(last, &clean_text) {
+                                    continue;
+                                }
+                            }
+
+                            // Skip repeated table headers from progress display
+                            if is_progress_table_header(&clean_text) {
+                                // Only skip if we've seen content before
+                                if last_line.is_some() {
+                                    continue;
+                                }
+                            }
+
+                            last_line = Some(clean_text.clone());
+
+                            let output_line = OutputLine {
+                                text: clean_text,
+                                is_error: false,
+                                timestamp: std::time::Instant::now(),
+                            };
+                            if sync_tx_reader
+                                .send(CommandResult::OutputLine(output_line))
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            // Wait for process to complete
+            match child.wait() {
+                Ok(status) => {
+                    // Wait for reader to finish
+                    let _ = reader_thread.join();
+
+                    let exit_code = status.exit_code() as i32;
+                    log::info!("Command completed with exit code: {}", exit_code);
+                    let _ = sync_tx.send(CommandResult::Completed { exit_code });
+                }
+                Err(e) => {
+                    log::error!("Failed to wait for command: {}", e);
+                    let _ = sync_tx.send(CommandResult::Failed(e.to_string()));
+                }
+            }
+        });
+
+        // Forward results from sync channel to async channel
+        loop {
+            match sync_rx.recv() {
+                Ok(result) => {
+                    let is_terminal = matches!(
+                        result,
+                        CommandResult::Completed { .. } | CommandResult::Failed(_)
+                    );
+                    if tx.send(result).await.is_err() {
+                        break;
+                    }
+                    if is_terminal {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Wait for PTY thread to finish
+        let _ = pty_thread.join();
+    });
+}
+
+/// Check if two lines are duplicate progress updates
+/// Pulumi updates the same line in place with different counts
+fn is_duplicate_progress_line(prev: &str, current: &str) -> bool {
+    // If lines are exactly the same, it's a duplicate
+    if prev == current {
+        return true;
+    }
+
+    // Check if both lines are progress table rows (Type/Name/Plan format)
+    // These lines look like: "pulumi:pulumi:Stack  project-name  running"
+    // Only the status or count changes
+
+    // Extract the first two columns (type and name) and compare
+    let prev_parts: Vec<&str> = prev.split_whitespace().collect();
+    let curr_parts: Vec<&str> = current.split_whitespace().collect();
+
+    // Both must have at least 2 parts
+    if prev_parts.len() >= 2 && curr_parts.len() >= 2 {
+        // If type and name are the same, and this looks like a status update
+        if prev_parts[0] == curr_parts[0] && prev_parts[1] == curr_parts[1] {
+            // Check if the last part is a status indicator
+            let statuses = ["running", "creating", "updating", "deleting", "reading"];
+            let prev_has_status = prev_parts.last().map(|s| statuses.contains(s)).unwrap_or(false);
+            let curr_has_status = curr_parts.last().map(|s| statuses.contains(s)).unwrap_or(false);
+            if prev_has_status || curr_has_status {
+                return true;
+            }
+        }
+    }
+
+    // Check if both are "Resources:" count lines - keep only the last one
+    if prev.starts_with("Resources:") && current.starts_with("Resources:") {
+        return true;
+    }
+
+    // Check if both are count lines like "102 unchanged"
+    if is_resource_count_line(prev) && is_resource_count_line(current) {
+        return true;
+    }
+
+    false
+}
+
+/// Check if a line is a resource count line (e.g., "102 unchanged")
+fn is_resource_count_line(line: &str) -> bool {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() >= 2 {
+        // First part should be a number
+        if parts[0].parse::<u32>().is_ok() {
+            let status_words = ["unchanged", "created", "updated", "deleted", "replaced"];
+            return status_words.iter().any(|w| parts[1].contains(w));
+        }
+    }
+    false
+}
+
+/// Check if a line is a progress table header
+fn is_progress_table_header(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed == "Type"
+        || trimmed == "Name"
+        || trimmed == "Plan"
+        || trimmed == "Status"
+        || trimmed == "Type                          Name                    Plan"
+        || (trimmed.starts_with("Type") && trimmed.contains("Name") && trimmed.contains("Plan"))
+}
+
+/// Strip ANSI escape codes and control characters from text
+fn strip_ansi_codes(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // ESC character - skip the escape sequence
+            if chars.peek() == Some(&'[') {
+                chars.next(); // consume '['
+                // Skip until we find a letter (end of CSI sequence)
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next.is_ascii_alphabetic() || next == 'm' || next == 'K' || next == 'H' {
+                        break;
+                    }
+                }
+            } else if chars.peek() == Some(&']') {
+                // OSC sequence - skip until ST or BEL
+                chars.next();
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next == '\x07' || next == '\\' {
+                        break;
+                    }
+                }
+            }
+        } else if c == '\r' {
+            // Carriage return - skip (handle \r\n as just \n)
+            continue;
+        } else if c.is_control() && c != '\n' && c != '\t' {
+            // Skip other control characters
+            continue;
+        } else {
+            result.push(c);
+        }
+    }
+
+    result.trim().to_string()
+}
+
+/// Check if the command can be run (not interactive)
+pub fn can_run_command(execution: &CommandExecution) -> Result<(), String> {
+    use super::types::ExecutionMode;
+
+    if execution.command.execution_mode == ExecutionMode::Interactive {
+        return Err(format!(
+            "Command '{}' requires interactive mode and cannot be run in the TUI. \
+             Please run it directly in your terminal.",
+            execution.command.name
+        ));
+    }
+
+    // Check required parameters
+    for param in execution.command.params {
+        if param.required {
+            let value = execution.param_values.get(param.name);
+            if value.is_none() || value.map(|v| v.is_empty()).unwrap_or(true) {
+                return Err(format!("Required parameter '{}' is missing", param.name));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Update execution state based on result
+pub fn update_execution_state(execution: &mut CommandExecution, result: CommandResult) {
+    match result {
+        CommandResult::OutputLine(line) => {
+            // Additional deduplication at the state level
+            // Skip if this exact line was just added
+            if let Some(last) = execution.output_lines.last() {
+                if last.text == line.text {
+                    return;
+                }
+            }
+            execution.output_lines.push(line);
+        }
+        CommandResult::Completed { exit_code } => {
+            execution.exit_code = Some(exit_code);
+            if exit_code == 0 {
+                execution.state = CommandExecutionState::Completed;
+            } else {
+                execution.state = CommandExecutionState::Failed(format!("Exit code: {}", exit_code));
+            }
+        }
+        CommandResult::Failed(error) => {
+            execution.state = CommandExecutionState::Failed(error);
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,10 @@
+//! Pulumi CLI commands module
+//!
+//! This module defines the Pulumi CLI commands available in the TUI
+//! and handles their execution with parameter dialogs and output streaming.
+
+mod types;
+mod executor;
+
+pub use types::*;
+pub use executor::*;

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -1,0 +1,806 @@
+//! Pulumi CLI command definitions
+//!
+//! Defines the available Pulumi commands with their parameters and categories.
+
+use std::fmt;
+
+/// Category of Pulumi commands
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandCategory {
+    /// Core stack operations (up, preview, destroy, refresh)
+    StackOperations,
+    /// Stack and config management
+    StackManagement,
+    /// Project and template operations
+    ProjectManagement,
+    /// Authentication and organization
+    AuthOrg,
+    /// Utilities and info
+    Utilities,
+}
+
+impl CommandCategory {
+    pub fn all() -> &'static [CommandCategory] {
+        &[
+            CommandCategory::StackOperations,
+            CommandCategory::StackManagement,
+            CommandCategory::ProjectManagement,
+            CommandCategory::AuthOrg,
+            CommandCategory::Utilities,
+        ]
+    }
+
+    pub fn title(&self) -> &'static str {
+        match self {
+            CommandCategory::StackOperations => "Stack Operations",
+            CommandCategory::StackManagement => "Stack Management",
+            CommandCategory::ProjectManagement => "Project Management",
+            CommandCategory::AuthOrg => "Auth & Organization",
+            CommandCategory::Utilities => "Utilities",
+        }
+    }
+
+    pub fn icon(&self) -> &'static str {
+        match self {
+            CommandCategory::StackOperations => ">>",
+            CommandCategory::StackManagement => "[]",
+            CommandCategory::ProjectManagement => "{}",
+            CommandCategory::AuthOrg => "**",
+            CommandCategory::Utilities => "##",
+        }
+    }
+}
+
+impl fmt::Display for CommandCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.title())
+    }
+}
+
+/// A parameter for a Pulumi command
+#[derive(Debug, Clone)]
+pub struct CommandParam {
+    /// Parameter name (e.g., "stack", "message")
+    pub name: &'static str,
+    /// Short flag (e.g., "-s")
+    pub short: Option<&'static str>,
+    /// Long flag (e.g., "--stack")
+    pub long: Option<&'static str>,
+    /// Description shown in the dialog
+    pub description: &'static str,
+    /// Whether this parameter is required
+    pub required: bool,
+    /// Default value if any
+    pub default: Option<&'static str>,
+    /// Parameter type for input handling
+    pub param_type: ParamType,
+}
+
+/// Type of parameter for input handling
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum ParamType {
+    /// Simple text input
+    Text,
+    /// Boolean flag (yes/no)
+    Flag,
+    /// Stack selector (uses stack list)
+    Stack,
+    /// File path selector
+    FilePath,
+    /// Secret value (hidden input)
+    Secret,
+    /// Multi-line text
+    MultiLine,
+}
+
+/// Execution mode for a command
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionMode {
+    /// Command shows streaming output (up, destroy, refresh, preview)
+    Streaming,
+    /// Command runs quickly and shows result
+    Quick,
+    /// Command opens interactive mode (not supported in TUI)
+    Interactive,
+}
+
+/// Definition of a Pulumi CLI command
+#[derive(Debug, Clone)]
+pub struct PulumiCommand {
+    /// Command name (e.g., "up", "preview")
+    pub name: &'static str,
+    /// CLI command (e.g., ["stack", "ls"] for "pulumi stack ls")
+    pub cli_args: &'static [&'static str],
+    /// Brief description
+    pub description: &'static str,
+    /// Category
+    pub category: CommandCategory,
+    /// Command parameters
+    pub params: &'static [CommandParam],
+    /// Whether this command needs confirmation before running
+    pub needs_confirmation: bool,
+    /// Execution mode
+    pub execution_mode: ExecutionMode,
+    /// Keyboard shortcut hint (e.g., "u" for up)
+    pub shortcut: Option<char>,
+    /// Whether this command supports working directory selection
+    #[allow(dead_code)]
+    pub supports_cwd: bool,
+}
+
+impl PulumiCommand {
+    /// Get the full command string for display
+    pub fn display_command(&self) -> String {
+        if self.cli_args.is_empty() {
+            format!("pulumi {}", self.name)
+        } else {
+            format!("pulumi {}", self.cli_args.join(" "))
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Command Definitions
+// ─────────────────────────────────────────────────────────────
+
+/// Stack selection parameter
+const PARAM_STACK: CommandParam = CommandParam {
+    name: "stack",
+    short: Some("-s"),
+    long: Some("--stack"),
+    description: "Target stack name",
+    required: false,
+    default: None,
+    param_type: ParamType::Stack,
+};
+
+/// Yes/skip confirmation parameter
+const PARAM_YES: CommandParam = CommandParam {
+    name: "yes",
+    short: Some("-y"),
+    long: Some("--yes"),
+    description: "Skip confirmation prompts",
+    required: false,
+    default: Some("true"),
+    param_type: ParamType::Flag,
+};
+
+/// Message parameter for updates
+const PARAM_MESSAGE: CommandParam = CommandParam {
+    name: "message",
+    short: Some("-m"),
+    long: Some("--message"),
+    description: "Update message",
+    required: false,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Config key parameter
+const PARAM_CONFIG_KEY: CommandParam = CommandParam {
+    name: "key",
+    short: None,
+    long: None,
+    description: "Configuration key",
+    required: true,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Config value parameter
+const PARAM_CONFIG_VALUE: CommandParam = CommandParam {
+    name: "value",
+    short: None,
+    long: None,
+    description: "Configuration value",
+    required: true,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Secret flag for config
+const PARAM_SECRET: CommandParam = CommandParam {
+    name: "secret",
+    short: None,
+    long: Some("--secret"),
+    description: "Treat value as secret",
+    required: false,
+    default: None,
+    param_type: ParamType::Flag,
+};
+
+/// Stack name for creation (positional argument for stack init/select/rm)
+const PARAM_STACK_NAME: CommandParam = CommandParam {
+    name: "name",
+    short: None,
+    long: None,
+    description: "Stack name to create",
+    required: true,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Initial stack name for new project (uses -s, --stack)
+const PARAM_NEW_STACK: CommandParam = CommandParam {
+    name: "stack",
+    short: Some("-s"),
+    long: Some("--stack"),
+    description: "Initial stack name",
+    required: false,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Template parameter for new project
+const PARAM_TEMPLATE: CommandParam = CommandParam {
+    name: "template",
+    short: None,
+    long: None,
+    description: "Template name (e.g., aws-typescript)",
+    required: false,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Project name parameter
+const PARAM_PROJECT_NAME: CommandParam = CommandParam {
+    name: "name",
+    short: Some("-n"),
+    long: Some("--name"),
+    description: "Project name",
+    required: false,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Diff flag for preview
+const PARAM_DIFF: CommandParam = CommandParam {
+    name: "diff",
+    short: None,
+    long: Some("--diff"),
+    description: "Show detailed diff",
+    required: false,
+    default: None,
+    param_type: ParamType::Flag,
+};
+
+/// Target parameter
+const PARAM_TARGET: CommandParam = CommandParam {
+    name: "target",
+    short: Some("-t"),
+    long: Some("--target"),
+    description: "Target specific resources (URN)",
+    required: false,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// JSON output flag
+const PARAM_JSON: CommandParam = CommandParam {
+    name: "json",
+    short: Some("-j"),
+    long: Some("--json"),
+    description: "Output as JSON",
+    required: false,
+    default: None,
+    param_type: ParamType::Flag,
+};
+
+/// Working directory parameter (special - handled separately)
+const PARAM_CWD: CommandParam = CommandParam {
+    name: "cwd",
+    short: Some("-C"),
+    long: Some("--cwd"),
+    description: "Working directory (leave empty for current)",
+    required: false,
+    default: None,
+    param_type: ParamType::FilePath,
+};
+
+/// Description for new project
+const PARAM_DESCRIPTION: CommandParam = CommandParam {
+    name: "description",
+    short: Some("-d"),
+    long: Some("--description"),
+    description: "Project description",
+    required: false,
+    default: None,
+    param_type: ParamType::Text,
+};
+
+/// Generate only flag for new project
+const PARAM_GENERATE_ONLY: CommandParam = CommandParam {
+    name: "generate-only",
+    short: Some("-g"),
+    long: Some("--generate-only"),
+    description: "Generate project files only (skip install)",
+    required: false,
+    default: None,
+    param_type: ParamType::Flag,
+};
+
+// ─────────────────────────────────────────────────────────────
+// All Commands
+// ─────────────────────────────────────────────────────────────
+
+pub static PULUMI_COMMANDS: &[PulumiCommand] = &[
+    // Stack Operations
+    PulumiCommand {
+        name: "up",
+        cli_args: &["up"],
+        description: "Deploy infrastructure changes",
+        category: CommandCategory::StackOperations,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_YES, PARAM_MESSAGE, PARAM_TARGET, PARAM_DIFF],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('u'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "preview",
+        cli_args: &["preview"],
+        description: "Preview changes without deploying",
+        category: CommandCategory::StackOperations,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_DIFF, PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('p'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "destroy",
+        cli_args: &["destroy"],
+        description: "Destroy all infrastructure",
+        category: CommandCategory::StackOperations,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_YES, PARAM_TARGET],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('d'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "refresh",
+        cli_args: &["refresh"],
+        description: "Refresh state from cloud provider",
+        category: CommandCategory::StackOperations,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_YES],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('r'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "cancel",
+        cli_args: &["cancel"],
+        description: "Cancel running update",
+        category: CommandCategory::StackOperations,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_YES],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "watch",
+        cli_args: &["watch"],
+        description: "Watch for file changes and update",
+        category: CommandCategory::StackOperations,
+        params: &[PARAM_CWD, PARAM_STACK],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('w'),
+        supports_cwd: true,
+    },
+
+    // Stack Management
+    PulumiCommand {
+        name: "stack ls",
+        cli_args: &["stack", "ls"],
+        description: "List all stacks",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "stack select",
+        cli_args: &["stack", "select"],
+        description: "Select active stack",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK_NAME],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "stack init",
+        cli_args: &["stack", "init"],
+        description: "Create a new stack",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK_NAME],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "stack rm",
+        cli_args: &["stack", "rm"],
+        description: "Remove a stack",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK_NAME, PARAM_YES],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "stack output",
+        cli_args: &["stack", "output"],
+        description: "Show stack outputs",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: Some('o'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "stack history",
+        cli_args: &["stack", "history"],
+        description: "Show stack update history",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "stack export",
+        cli_args: &["stack", "export"],
+        description: "Export stack state",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "config set",
+        cli_args: &["config", "set"],
+        description: "Set a config value",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_CONFIG_KEY, PARAM_CONFIG_VALUE, PARAM_SECRET, PARAM_STACK],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "config get",
+        cli_args: &["config", "get"],
+        description: "Get a config value",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_CONFIG_KEY, PARAM_STACK],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "config",
+        cli_args: &["config"],
+        description: "Show all config values",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: Some('c'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "config rm",
+        cli_args: &["config", "rm"],
+        description: "Remove a config value",
+        category: CommandCategory::StackManagement,
+        params: &[PARAM_CWD, PARAM_CONFIG_KEY, PARAM_STACK],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+
+    // Project Management
+    PulumiCommand {
+        name: "new",
+        cli_args: &["new", "--force"],
+        description: "Create a new Pulumi project",
+        category: CommandCategory::ProjectManagement,
+        params: &[PARAM_CWD, PARAM_TEMPLATE, PARAM_PROJECT_NAME, PARAM_NEW_STACK, PARAM_DESCRIPTION, PARAM_GENERATE_ONLY, PARAM_YES],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('n'),
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "import",
+        cli_args: &["import"],
+        description: "Import existing resources",
+        category: CommandCategory::ProjectManagement,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_YES],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "install",
+        cli_args: &["install"],
+        description: "Install plugins and dependencies",
+        category: CommandCategory::ProjectManagement,
+        params: &[PARAM_CWD],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "logs",
+        cli_args: &["logs"],
+        description: "Show aggregated resource logs",
+        category: CommandCategory::ProjectManagement,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Streaming,
+        shortcut: Some('l'),
+        supports_cwd: true,
+    },
+
+    // Auth & Organization
+    PulumiCommand {
+        name: "login",
+        cli_args: &["login"],
+        description: "Log in to Pulumi Cloud",
+        category: CommandCategory::AuthOrg,
+        params: &[],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: false,
+    },
+    PulumiCommand {
+        name: "logout",
+        cli_args: &["logout"],
+        description: "Log out of Pulumi Cloud",
+        category: CommandCategory::AuthOrg,
+        params: &[],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: false,
+    },
+    PulumiCommand {
+        name: "whoami",
+        cli_args: &["whoami"],
+        description: "Show current logged-in user",
+        category: CommandCategory::AuthOrg,
+        params: &[],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: false,
+    },
+    PulumiCommand {
+        name: "org get-default",
+        cli_args: &["org", "get-default"],
+        description: "Show default organization",
+        category: CommandCategory::AuthOrg,
+        params: &[],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: false,
+    },
+    PulumiCommand {
+        name: "console",
+        cli_args: &["console"],
+        description: "Open in Pulumi Console",
+        category: CommandCategory::AuthOrg,
+        params: &[PARAM_CWD, PARAM_STACK],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+
+    // Utilities
+    PulumiCommand {
+        name: "version",
+        cli_args: &["version"],
+        description: "Show Pulumi version",
+        category: CommandCategory::Utilities,
+        params: &[],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: false,
+    },
+    PulumiCommand {
+        name: "about",
+        cli_args: &["about"],
+        description: "Show environment info",
+        category: CommandCategory::Utilities,
+        params: &[PARAM_CWD],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+    PulumiCommand {
+        name: "plugin ls",
+        cli_args: &["plugin", "ls"],
+        description: "List installed plugins",
+        category: CommandCategory::Utilities,
+        params: &[PARAM_JSON],
+        needs_confirmation: false,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: false,
+    },
+    PulumiCommand {
+        name: "state delete",
+        cli_args: &["state", "delete"],
+        description: "Delete resource from state",
+        category: CommandCategory::Utilities,
+        params: &[PARAM_CWD, PARAM_STACK, PARAM_YES],
+        needs_confirmation: true,
+        execution_mode: ExecutionMode::Quick,
+        shortcut: None,
+        supports_cwd: true,
+    },
+];
+
+/// Get commands by category
+pub fn commands_by_category(category: CommandCategory) -> Vec<&'static PulumiCommand> {
+    PULUMI_COMMANDS
+        .iter()
+        .filter(|cmd| cmd.category == category)
+        .collect()
+}
+
+/// Get all categories with their commands count
+#[allow(dead_code)]
+pub fn categories_with_counts() -> Vec<(CommandCategory, usize)> {
+    CommandCategory::all()
+        .iter()
+        .map(|&cat| (cat, commands_by_category(cat).len()))
+        .collect()
+}
+
+/// Execution state of a command
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum CommandExecutionState {
+    /// Not running
+    Idle,
+    /// Waiting for user to fill parameters
+    AwaitingInput,
+    /// Waiting for confirmation
+    AwaitingConfirmation,
+    /// Currently executing
+    Running,
+    /// Completed successfully
+    Completed,
+    /// Failed with error
+    Failed(String),
+}
+
+/// A command execution instance with parameters
+#[derive(Debug, Clone)]
+pub struct CommandExecution {
+    /// The command being executed
+    pub command: &'static PulumiCommand,
+    /// Parameter values (key -> value)
+    pub param_values: std::collections::HashMap<String, String>,
+    /// Execution state
+    pub state: CommandExecutionState,
+    /// Output lines collected
+    pub output_lines: Vec<OutputLine>,
+    /// Exit code if completed
+    pub exit_code: Option<i32>,
+}
+
+/// A line of command output
+#[derive(Debug, Clone)]
+pub struct OutputLine {
+    /// The text content
+    pub text: String,
+    /// Whether this is stderr (vs stdout)
+    pub is_error: bool,
+    /// Timestamp
+    #[allow(dead_code)]
+    pub timestamp: std::time::Instant,
+}
+
+impl CommandExecution {
+    pub fn new(command: &'static PulumiCommand) -> Self {
+        Self {
+            command,
+            param_values: std::collections::HashMap::new(),
+            state: CommandExecutionState::AwaitingInput,
+            output_lines: Vec::new(),
+            exit_code: None,
+        }
+    }
+
+    /// Get the working directory if specified (cwd parameter is handled separately)
+    pub fn get_working_directory(&self) -> Option<String> {
+        self.param_values.get("cwd").and_then(|v| {
+            if v.is_empty() {
+                None
+            } else {
+                Some(v.clone())
+            }
+        })
+    }
+
+    /// Build the full command line arguments
+    /// Note: The "cwd" parameter is not included here as it's handled via current_dir()
+    pub fn build_args(&self) -> Vec<String> {
+        let mut args: Vec<String> = self.command.cli_args.iter().map(|s| s.to_string()).collect();
+
+        for param in self.command.params {
+            // Skip cwd parameter - it's handled separately via current_dir()
+            if param.name == "cwd" {
+                continue;
+            }
+
+            if let Some(value) = self.param_values.get(param.name) {
+                if value.is_empty() {
+                    continue;
+                }
+
+                match param.param_type {
+                    ParamType::Flag => {
+                        if value == "true" || value == "yes" {
+                            if let Some(long) = param.long {
+                                args.push(long.to_string());
+                            } else if let Some(short) = param.short {
+                                args.push(short.to_string());
+                            }
+                        }
+                    }
+                    _ => {
+                        // For positional arguments (no flags), just add the value
+                        if param.long.is_none() && param.short.is_none() {
+                            args.push(value.clone());
+                        } else if let Some(long) = param.long {
+                            args.push(long.to_string());
+                            args.push(value.clone());
+                        } else if let Some(short) = param.short {
+                            args.push(short.to_string());
+                            args.push(value.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        args
+    }
+
+    /// Get the display command string with parameters
+    pub fn display_with_params(&self) -> String {
+        let args = self.build_args();
+        let cwd_prefix = self.get_working_directory()
+            .map(|d| format!("(in {}) ", d))
+            .unwrap_or_default();
+        format!("{}pulumi {}", cwd_prefix, args.join(" "))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod api;
 mod app;
+mod commands;
 mod components;
 mod config;
 mod event;

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -9,6 +9,7 @@ Renders application state to Ratatui frames.
 | File | View | Description |
 |------|------|-------------|
 | `dashboard.rs` | Dashboard | Stats cards, resource chart, recent updates |
+| `commands.rs` | Commands | Pulumi CLI command execution with streaming output |
 | `stacks.rs` | Stacks | Stack list and update history |
 | `esc.rs` | ESC | Environments list, YAML editor |
 | `neo.rs` | Neo | Chat interface with markdown rendering |
@@ -72,3 +73,20 @@ Dedicated 2-line area between chat and input:
 4. **Background polling**: Poll every few seconds when tab active
 
 Reference: [Tenere](https://github.com/pythops/tenere), [tui-scrollview](https://github.com/joshka/tui-scrollview)
+
+## Commands View
+
+Renders Pulumi CLI command execution interface (LazyGit-style).
+
+### Layout
+- **Left panel**: Command categories and commands list
+- **Input dialog**: Parameter input fields (popup)
+- **Confirm dialog**: Yes/No for destructive commands
+- **Output view**: Streaming command output with scroll
+
+### Output Colorization
+`colorize_pulumi_output()` applies colors based on content:
+- Green: created, succeeded, unchanged
+- Red: deleted, failed, error
+- Yellow: updated, warning
+- Cyan: reading, refreshing

--- a/src/ui/commands.rs
+++ b/src/ui/commands.rs
@@ -1,0 +1,835 @@
+//! Commands view rendering
+//!
+//! Renders the Pulumi CLI commands interface with categories,
+//! command list, parameter dialogs, and output display.
+
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::*,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
+};
+use tui_scrollview::ScrollViewState;
+
+use crate::commands::{
+    CommandCategory, CommandExecution, CommandExecutionState, ExecutionMode,
+    PulumiCommand, commands_by_category,
+};
+use crate::components::{StatefulList, TextInput};
+use crate::theme::{symbols, Theme};
+
+/// State for the commands view
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandsViewState {
+    /// Browsing categories
+    BrowsingCategories,
+    /// Browsing commands in a category
+    BrowsingCommands,
+    /// Showing parameter input dialog
+    InputDialog,
+    /// Showing confirmation dialog
+    ConfirmDialog,
+    /// Showing command output
+    OutputView,
+}
+
+impl Default for CommandsViewState {
+    fn default() -> Self {
+        Self::BrowsingCategories
+    }
+}
+
+/// Render the commands view
+pub fn render_commands_view(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    view_state: CommandsViewState,
+    category_list: &mut StatefulList<CommandCategory>,
+    command_list: &mut StatefulList<&'static PulumiCommand>,
+    current_execution: Option<&CommandExecution>,
+    param_inputs: &[TextInput],
+    param_focus_index: usize,
+    output_scroll: &mut ScrollViewState,
+    filter_input: &TextInput,
+    is_filtering: bool,
+) {
+    // Main layout: left sidebar for categories/commands, right for details/output
+    let main_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+        .split(area);
+
+    // Left sidebar: categories + commands
+    render_sidebar(
+        frame,
+        theme,
+        main_chunks[0],
+        view_state,
+        category_list,
+        command_list,
+        filter_input,
+        is_filtering,
+    );
+
+    // Right panel: command details or output
+    render_main_panel(
+        frame,
+        theme,
+        main_chunks[1],
+        view_state,
+        command_list.selected().copied(),
+        current_execution,
+        output_scroll,
+    );
+
+    // Overlay dialogs
+    if view_state == CommandsViewState::InputDialog {
+        if let Some(exec) = current_execution {
+            render_input_dialog(frame, theme, exec, param_inputs, param_focus_index);
+        }
+    }
+
+    if view_state == CommandsViewState::ConfirmDialog {
+        if let Some(exec) = current_execution {
+            render_confirm_dialog(frame, theme, exec);
+        }
+    }
+}
+
+/// Render the left sidebar with categories and commands
+fn render_sidebar(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    view_state: CommandsViewState,
+    category_list: &mut StatefulList<CommandCategory>,
+    command_list: &mut StatefulList<&'static PulumiCommand>,
+    filter_input: &TextInput,
+    is_filtering: bool,
+) {
+    // Split into filter input and lists
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // Filter/search
+            Constraint::Min(5),     // Lists
+        ])
+        .split(area);
+
+    // Filter/search input
+    render_filter_input(frame, theme, chunks[0], filter_input, is_filtering);
+
+    // Categories and commands in a vertical split
+    let list_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(chunks[1]);
+
+    // Categories list
+    render_categories_list(frame, theme, list_chunks[0], category_list, view_state);
+
+    // Commands list
+    render_commands_list(frame, theme, list_chunks[1], command_list, view_state);
+}
+
+/// Render the filter input
+fn render_filter_input(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    input: &TextInput,
+    is_focused: bool,
+) {
+    let border_style = if is_focused {
+        theme.border_focused()
+    } else {
+        theme.border()
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(" / Search ")
+        .title_style(if is_focused { theme.title() } else { theme.subtitle() });
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let value = input.value();
+    let display_value = if value.is_empty() && !is_focused {
+        "Type / to filter commands...".to_string()
+    } else {
+        value.to_string()
+    };
+
+    let style = if value.is_empty() && !is_focused {
+        theme.text_muted()
+    } else {
+        theme.text()
+    };
+
+    let text = Paragraph::new(display_value).style(style);
+    frame.render_widget(text, inner);
+
+    // Render cursor if focused
+    if is_focused {
+        let cursor_x = inner.x + input.cursor() as u16;
+        let cursor_y = inner.y;
+        if cursor_x < inner.x + inner.width {
+            frame.set_cursor_position((cursor_x, cursor_y));
+        }
+    }
+}
+
+/// Render the categories list
+fn render_categories_list(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    category_list: &mut StatefulList<CommandCategory>,
+    view_state: CommandsViewState,
+) {
+    let is_focused = view_state == CommandsViewState::BrowsingCategories;
+    let selected_idx = category_list.selected_index();
+
+    let items: Vec<ListItem> = category_list
+        .items()
+        .iter()
+        .enumerate()
+        .map(|(i, cat)| {
+            let is_selected = selected_idx == Some(i);
+            let cmd_count = commands_by_category(*cat).len();
+
+            let prefix = if is_selected && is_focused {
+                format!("{} ", symbols::ARROW_RIGHT)
+            } else {
+                "  ".to_string()
+            };
+
+            let content = Line::from(vec![
+                Span::styled(prefix, theme.primary()),
+                Span::styled(cat.icon(), theme.accent()),
+                Span::styled(" ", theme.text()),
+                Span::styled(cat.title(), if is_selected && is_focused { theme.primary() } else { theme.text() }),
+                Span::styled(format!(" ({})", cmd_count), theme.text_muted()),
+            ]);
+
+            ListItem::new(content)
+        })
+        .collect();
+
+    let border_style = if is_focused {
+        theme.border_focused()
+    } else {
+        theme.border()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Categories ")
+                .title_style(if is_focused { theme.title() } else { theme.subtitle() }),
+        )
+        .highlight_style(theme.selected())
+        .highlight_symbol("");
+
+    frame.render_stateful_widget(list, area, &mut category_list.state);
+}
+
+/// Render the commands list
+fn render_commands_list(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    command_list: &mut StatefulList<&'static PulumiCommand>,
+    view_state: CommandsViewState,
+) {
+    let is_focused = view_state == CommandsViewState::BrowsingCommands;
+    let selected_idx = command_list.selected_index();
+
+    let items: Vec<ListItem> = command_list
+        .items()
+        .iter()
+        .enumerate()
+        .map(|(i, cmd)| {
+            let is_selected = selected_idx == Some(i);
+
+            let prefix = if is_selected && is_focused {
+                format!("{} ", symbols::ARROW_RIGHT)
+            } else {
+                "  ".to_string()
+            };
+
+            // Shortcut hint
+            let shortcut = cmd.shortcut
+                .map(|c| format!("[{}] ", c))
+                .unwrap_or_default();
+
+            // Execution mode indicator
+            let mode_indicator = match cmd.execution_mode {
+                ExecutionMode::Streaming => symbols::ARROW_RIGHT,
+                ExecutionMode::Quick => symbols::BULLET,
+                ExecutionMode::Interactive => symbols::STAR,
+            };
+
+            let content = Line::from(vec![
+                Span::styled(prefix, theme.primary()),
+                Span::styled(shortcut, theme.accent()),
+                Span::styled(cmd.name, if is_selected && is_focused { theme.primary() } else { theme.text() }),
+                Span::styled(" ", theme.text()),
+                Span::styled(mode_indicator, theme.text_muted()),
+            ]);
+
+            ListItem::new(content)
+        })
+        .collect();
+
+    let border_style = if is_focused {
+        theme.border_focused()
+    } else {
+        theme.border()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Commands ")
+                .title_style(if is_focused { theme.title() } else { theme.subtitle() }),
+        )
+        .highlight_style(theme.selected())
+        .highlight_symbol("");
+
+    frame.render_stateful_widget(list, area, &mut command_list.state);
+}
+
+/// Render the main panel (details or output)
+fn render_main_panel(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    view_state: CommandsViewState,
+    selected_command: Option<&'static PulumiCommand>,
+    current_execution: Option<&CommandExecution>,
+    output_scroll: &mut ScrollViewState,
+) {
+    // If we're in output view, show the output
+    if view_state == CommandsViewState::OutputView {
+        if let Some(exec) = current_execution {
+            render_output_view(frame, theme, area, exec, output_scroll);
+            return;
+        }
+    }
+
+    // Otherwise, show command details
+    render_command_details(frame, theme, area, selected_command);
+}
+
+/// Render command details panel
+fn render_command_details(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    selected_command: Option<&'static PulumiCommand>,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border())
+        .title(" Command Details ")
+        .title_style(theme.subtitle());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    match selected_command {
+        Some(cmd) => {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(6),  // Header info
+                    Constraint::Length(2),  // Separator
+                    Constraint::Min(5),     // Parameters
+                ])
+                .split(inner);
+
+            // Command header
+            let header_lines = vec![
+                Line::from(vec![
+                    Span::styled("Command: ", theme.text_secondary()),
+                    Span::styled(cmd.display_command(), theme.primary()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Description: ", theme.text_secondary()),
+                    Span::styled(cmd.description, theme.text()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Category: ", theme.text_secondary()),
+                    Span::styled(cmd.category.title(), theme.accent()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Mode: ", theme.text_secondary()),
+                    Span::styled(
+                        match cmd.execution_mode {
+                            ExecutionMode::Streaming => "Streaming output",
+                            ExecutionMode::Quick => "Quick execution",
+                            ExecutionMode::Interactive => "Interactive (not supported)",
+                        },
+                        match cmd.execution_mode {
+                            ExecutionMode::Interactive => theme.warning(),
+                            _ => theme.text(),
+                        },
+                    ),
+                ]),
+            ];
+            let header = Paragraph::new(header_lines);
+            frame.render_widget(header, chunks[0]);
+
+            // Separator
+            let sep = Paragraph::new(Line::from(vec![
+                Span::styled(format!("{} Parameters ", symbols::HORIZONTAL.repeat(3)), theme.text_muted()),
+                Span::styled(symbols::HORIZONTAL.repeat(chunks[1].width.saturating_sub(15) as usize), theme.text_muted()),
+            ]));
+            frame.render_widget(sep, chunks[1]);
+
+            // Parameters
+            if cmd.params.is_empty() {
+                let no_params = Paragraph::new("No parameters required")
+                    .style(theme.text_muted())
+                    .alignment(Alignment::Center);
+                frame.render_widget(no_params, chunks[2]);
+            } else {
+                let param_lines: Vec<Line> = cmd.params.iter().map(|p| {
+                    let flag_str = match (p.short, p.long) {
+                        (Some(s), Some(l)) => format!("{}, {}", s, l),
+                        (Some(s), None) => s.to_string(),
+                        (None, Some(l)) => l.to_string(),
+                        (None, None) => "<positional>".to_string(),
+                    };
+
+                    let required_str = if p.required { "*" } else { " " };
+
+                    Line::from(vec![
+                        Span::styled(required_str, theme.error()),
+                        Span::styled(format!("{:<20}", p.name), theme.primary()),
+                        Span::styled(format!("{:<15}", flag_str), theme.text_muted()),
+                        Span::styled(p.description, theme.text()),
+                    ])
+                }).collect();
+
+                let params = Paragraph::new(param_lines);
+                frame.render_widget(params, chunks[2]);
+            }
+
+            // Hint at bottom
+            let hint = if cmd.execution_mode == ExecutionMode::Interactive {
+                "This command requires interactive input and cannot run in the TUI"
+            } else if cmd.needs_confirmation {
+                "Press Enter to configure and run (requires confirmation)"
+            } else {
+                "Press Enter to configure and run"
+            };
+
+            let hint_area = Rect {
+                x: inner.x,
+                y: inner.y + inner.height.saturating_sub(1),
+                width: inner.width,
+                height: 1,
+            };
+            let hint_text = Paragraph::new(hint)
+                .style(theme.text_muted())
+                .alignment(Alignment::Center);
+            frame.render_widget(hint_text, hint_area);
+        }
+        None => {
+            let empty = Paragraph::new("Select a command to view details")
+                .style(theme.text_muted())
+                .alignment(Alignment::Center);
+            frame.render_widget(empty, inner);
+        }
+    }
+}
+
+/// Render the output view for a running/completed command
+fn render_output_view(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    execution: &CommandExecution,
+    scroll_state: &mut ScrollViewState,
+) {
+    // Split into header and output
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),  // Header with command info
+            Constraint::Min(5),     // Output area
+            Constraint::Length(1),  // Status bar
+        ])
+        .split(area);
+
+    // Header
+    let status_style = match &execution.state {
+        CommandExecutionState::Running => theme.warning(),
+        CommandExecutionState::Completed => theme.success(),
+        CommandExecutionState::Failed(_) => theme.error(),
+        _ => theme.text(),
+    };
+
+    let status_text = match &execution.state {
+        CommandExecutionState::Running => "Running...".to_string(),
+        CommandExecutionState::Completed => format!("Completed (exit: {})", execution.exit_code.unwrap_or(0)),
+        CommandExecutionState::Failed(e) => format!("Failed: {}", e),
+        _ => "".to_string(),
+    };
+
+    let header_lines = vec![
+        Line::from(vec![
+            Span::styled("$ ", theme.primary()),
+            Span::styled(execution.display_with_params(), theme.text()),
+        ]),
+        Line::from(vec![
+            Span::styled("Status: ", theme.text_secondary()),
+            Span::styled(status_text, status_style),
+        ]),
+    ];
+
+    let header_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border())
+        .title(" Command ")
+        .title_style(theme.title());
+
+    let header_inner = header_block.inner(chunks[0]);
+    frame.render_widget(header_block, chunks[0]);
+    frame.render_widget(Paragraph::new(header_lines), header_inner);
+
+    // Output area
+    let output_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border_focused())
+        .title(" Output ")
+        .title_style(theme.subtitle());
+
+    let output_inner = output_block.inner(chunks[1]);
+    frame.render_widget(output_block, chunks[1]);
+
+    // Render output lines
+    let output_lines: Vec<Line> = execution.output_lines.iter().map(|line| {
+        let style = if line.is_error {
+            theme.error()
+        } else {
+            // Color code based on content for Pulumi output
+            colorize_pulumi_output(&line.text, theme)
+        };
+        Line::styled(&line.text, style)
+    }).collect();
+
+    // Calculate visible area and scroll
+    let visible_height = output_inner.height as usize;
+    let total_lines = output_lines.len();
+
+    // Get scroll position from state - use the y offset
+    let scroll_offset = scroll_state.offset().y as usize;
+
+    // Clamp scroll offset to valid range
+    let max_scroll = total_lines.saturating_sub(visible_height);
+    let scroll_offset = scroll_offset.min(max_scroll);
+
+    let visible_lines: Vec<Line> = output_lines
+        .into_iter()
+        .skip(scroll_offset)
+        .take(visible_height)
+        .collect();
+
+    let output_para = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
+    frame.render_widget(output_para, output_inner);
+
+    // Scrollbar
+    if total_lines > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("^"))
+            .end_symbol(Some("v"));
+
+        let mut scrollbar_state = ScrollbarState::new(total_lines)
+            .position(scroll_offset);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            chunks[1].inner(Margin { vertical: 1, horizontal: 0 }),
+            &mut scrollbar_state,
+        );
+    }
+
+    // Status bar with scroll hints
+    let scroll_hint = if total_lines > visible_height {
+        format!(" | Line {}-{}/{}", scroll_offset + 1, (scroll_offset + visible_height).min(total_lines), total_lines)
+    } else {
+        String::new()
+    };
+
+    let status_bar = match &execution.state {
+        CommandExecutionState::Running => format!("j/k: scroll | G: bottom{}", scroll_hint),
+        CommandExecutionState::Completed | CommandExecutionState::Failed(_) => {
+            format!("j/k: scroll | g/G: top/bottom | Esc: close{}", scroll_hint)
+        }
+        _ => String::new(),
+    };
+    let status = Paragraph::new(status_bar)
+        .style(theme.text_muted())
+        .alignment(Alignment::Center);
+    frame.render_widget(status, chunks[2]);
+}
+
+/// Colorize Pulumi output based on content
+fn colorize_pulumi_output<'a>(text: &'a str, theme: &Theme) -> Style {
+    let lower = text.to_lowercase();
+
+    if lower.contains("error") || lower.contains("failed") {
+        theme.error()
+    } else if lower.contains("warning") || lower.contains("warn") {
+        theme.warning()
+    } else if lower.contains("creating") || lower.contains("updating") {
+        theme.warning()
+    } else if lower.contains("created") || lower.contains("updated") || lower.contains("succeeded") {
+        theme.success()
+    } else if lower.contains("deleting") {
+        theme.error()
+    } else if lower.contains("deleted") {
+        theme.text_muted()
+    } else if text.starts_with('+') {
+        theme.success()
+    } else if text.starts_with('-') {
+        theme.error()
+    } else if text.starts_with('~') {
+        theme.warning()
+    } else if text.contains("Previewing") || text.contains("Updating") {
+        theme.primary()
+    } else if text.starts_with("    ") {
+        theme.text_secondary()
+    } else {
+        theme.text()
+    }
+}
+
+/// Render the parameter input dialog
+fn render_input_dialog(
+    frame: &mut Frame,
+    theme: &Theme,
+    execution: &CommandExecution,
+    param_inputs: &[TextInput],
+    focus_index: usize,
+) {
+    let area = centered_rect(60, 70, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border_focused())
+        .title(format!(" Configure: {} ", execution.command.name))
+        .title_style(theme.title());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Layout: parameters + buttons
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(5),     // Parameters
+            Constraint::Length(3),  // Buttons
+        ])
+        .split(inner);
+
+    // Render parameters
+    let params = execution.command.params;
+    if params.is_empty() {
+        let no_params = Paragraph::new("No parameters to configure")
+            .style(theme.text_muted())
+            .alignment(Alignment::Center);
+        frame.render_widget(no_params, chunks[0]);
+    } else {
+        // Calculate height per parameter: 1 line label + 3 lines input (border + content + border)
+        let param_height = 4u16;
+        let total_height = chunks[0].height;
+        let max_params = (total_height / param_height) as usize;
+
+        let visible_params = params.len().min(max_params);
+
+        for (i, param) in params.iter().take(visible_params).enumerate() {
+            let y_offset = i as u16 * param_height;
+            let param_area = Rect {
+                x: chunks[0].x,
+                y: chunks[0].y + y_offset,
+                width: chunks[0].width,
+                height: param_height,
+            };
+
+            let is_focused = i == focus_index;
+
+            // Label
+            let required_marker = if param.required { "*" } else { " " };
+            let label = Line::from(vec![
+                Span::styled(required_marker, theme.error()),
+                Span::styled(param.name, if is_focused { theme.primary() } else { theme.text() }),
+                Span::styled(": ", theme.text_muted()),
+                Span::styled(param.description, theme.text_muted()),
+            ]);
+            let label_area = Rect {
+                x: param_area.x,
+                y: param_area.y,
+                width: param_area.width,
+                height: 1,
+            };
+            frame.render_widget(Paragraph::new(label), label_area);
+
+            // Input box - needs height=3 for borders (top + content + bottom)
+            let input_area = Rect {
+                x: param_area.x + 2,
+                y: param_area.y + 1,
+                width: param_area.width.saturating_sub(4),
+                height: 3,
+            };
+
+            let input_style = if is_focused {
+                theme.border_focused()
+            } else {
+                theme.border()
+            };
+
+            let input_block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(input_style);
+
+            let input_inner = input_block.inner(input_area);
+
+            // Render input block
+            frame.render_widget(input_block, input_area);
+
+            // Render input value
+            if let Some(input) = param_inputs.get(i) {
+                let value = input.value();
+                let display = if value.is_empty() {
+                    param.default.unwrap_or("").to_string()
+                } else {
+                    value.to_string()
+                };
+
+                let style = if value.is_empty() && !is_focused {
+                    theme.text_muted()
+                } else {
+                    theme.text()
+                };
+
+                let text = Paragraph::new(display).style(style);
+                frame.render_widget(text, input_inner);
+
+                // Cursor
+                if is_focused {
+                    let cursor_x = input_inner.x + input.cursor() as u16;
+                    if cursor_x < input_inner.x + input_inner.width {
+                        frame.set_cursor_position((cursor_x, input_inner.y));
+                    }
+                }
+            }
+        }
+    }
+
+    // Buttons
+    let button_text = Line::from(vec![
+        Span::styled("[Enter] ", theme.accent()),
+        Span::styled("Run  ", theme.text()),
+        Span::styled("[Tab] ", theme.accent()),
+        Span::styled("Next  ", theme.text()),
+        Span::styled("[Esc] ", theme.accent()),
+        Span::styled("Cancel", theme.text()),
+    ]);
+    let buttons = Paragraph::new(button_text).alignment(Alignment::Center);
+    frame.render_widget(buttons, chunks[1]);
+}
+
+/// Render the confirmation dialog
+fn render_confirm_dialog(
+    frame: &mut Frame,
+    theme: &Theme,
+    execution: &CommandExecution,
+) {
+    let area = centered_rect(50, 30, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.warning())
+        .title(" Confirm Execution ")
+        .title_style(theme.warning());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(3),     // Message
+            Constraint::Length(3),  // Command preview
+            Constraint::Length(2),  // Buttons
+        ])
+        .split(inner);
+
+    // Warning message
+    let message = if execution.command.name == "destroy" {
+        "This will DESTROY all resources in your stack!\nThis action cannot be undone."
+    } else {
+        "This command will modify your infrastructure.\nAre you sure you want to continue?"
+    };
+
+    let msg_style = if execution.command.name == "destroy" {
+        theme.error()
+    } else {
+        theme.warning()
+    };
+
+    let msg = Paragraph::new(message)
+        .style(msg_style)
+        .alignment(Alignment::Center);
+    frame.render_widget(msg, chunks[0]);
+
+    // Command preview
+    let preview = Paragraph::new(format!("$ {}", execution.display_with_params()))
+        .style(theme.text_muted())
+        .alignment(Alignment::Center);
+    frame.render_widget(preview, chunks[1]);
+
+    // Buttons
+    let button_text = Line::from(vec![
+        Span::styled("[y] ", theme.success()),
+        Span::styled("Yes  ", theme.text()),
+        Span::styled("[n/Esc] ", theme.error()),
+        Span::styled("No", theme.text()),
+    ]);
+    let buttons = Paragraph::new(button_text).alignment(Alignment::Center);
+    frame.render_widget(buttons, chunks[2]);
+}
+
+/// Create a centered rect for dialogs
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Contains all view rendering logic for the TUI.
 
+mod commands;
 mod dashboard;
 mod esc;
 mod header;
@@ -14,6 +15,7 @@ mod splash;
 mod stacks;
 pub mod syntax;
 
+pub use commands::{render_commands_view, CommandsViewState};
 pub use dashboard::render_dashboard;
 pub use esc::{render_esc_view, render_esc_editor};
 pub use header::render_header;


### PR DESCRIPTION
## Summary

- Add a new Commands tab for running Pulumi CLI commands directly from the TUI with streaming output (LazyGit-style)
- Commands are organized by category: Stack Operations, Stack Management, Project Management, Auth & Organization, Utilities
- Features parameter input dialogs, confirmation dialogs for destructive commands, and real-time PTY-based streaming output
- Output is colorized based on Pulumi status and supports scrolling with j/k navigation

## Test plan

- [ ] Navigate to Commands tab and browse categories
- [ ] Run a non-destructive command (e.g., `pulumi version`, `whoami`)
- [ ] Run a command with parameters (e.g., `stack output` with stack name)
- [ ] Verify streaming output displays in real-time
- [ ] Test scroll navigation in output view (j/k, g/G)
- [ ] Verify destructive commands show confirmation dialog