### PR TITLE
Add Neo slash commands support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A stylish terminal UI for Pulumi Cloud, ESC, and Neo built with Ratatui.
 
+> [!NOTE]
+> **New in this version:** Neo now supports slash commands! Press `/` in the Neo view to access predefined prompts like `/get-started`, `/component-version-report`, and more. Commands are highlighted in purple and can be combined with custom text.
+
 ## Features
 
 - **Dashboard**: Overview of your Pulumi resources with quick stats
@@ -92,14 +95,17 @@ Logs are written to a file to avoid interfering with the TUI:
 |-----|--------|
 | `n` | Start new task |
 | `i` | Focus input field |
+| `/` | Open slash command picker |
 | `d` | Show task details (in full-width chat mode) |
-| `Enter` | Send message / Load selected task |
-| `Esc` | Show task list (exit full-width chat) / Unfocus input |
+| `Enter` | Send message / Load selected task / Insert command |
+| `Tab` | Insert selected command (in picker) |
+| `Esc` | Show task list (exit full-width chat) / Unfocus input / Close picker |
 | `j` / `k` | Scroll chat down/up (3 lines) |
 | `J` / `K` | Scroll chat by page |
 | `g` | Jump to oldest messages |
 | `G` | Jump to newest messages + enable auto-scroll |
 | `Page Up/Down` | Scroll messages |
+| `↑` / `↓` | Navigate command picker |
 
 ### Platform View
 | Key | Action |
@@ -192,6 +198,11 @@ Additional UI colors:
 
 The Neo view provides a rich chat interface for Pulumi's AI agent:
 
+- **Slash Commands**: Press `/` to access predefined prompts (e.g., `/get-started`, `/component-version-report`)
+  - Commands appear in a picker with descriptions
+  - Insert commands with Enter or Tab, then add custom text
+  - Multiple commands can be combined in a single message
+  - Commands are highlighted with purple background in the input
 - **Markdown Rendering**: Bold, italic, code blocks, headers, lists
 - **Auto-scroll**: Automatically scrolls to new messages
 - **Task Details Dialog**: Press `d` to view task metadata including:

--- a/src/api/CLAUDE.md
+++ b/src/api/CLAUDE.md
@@ -34,6 +34,45 @@ Field names: uses `created`/`modified` (NOT `createdAt`/`modifiedAt`)
 
 Event body types: `user_message`, `assistant_message`, `set_task_name`, `exec_tool_call`, `tool_response`, `user_approval_request`
 
+### Neo Slash Commands
+- `GET /api/console/agents/{org}/commands` - List available slash commands
+
+**New task** with slash commands (uses `message` wrapper):
+```json
+{
+  "message": {
+    "type": "user_message",
+    "content": "{{cmd:name:tag}}",
+    "timestamp": "2025-12-05T20:45:08.613Z",
+    "commands": {
+      "{{cmd:name:tag}}": {
+        "name": "command-name",
+        "prompt": "Full prompt text...",
+        "description": "Short description",
+        "builtIn": true,
+        "modifiedAt": "0001-01-01T00:00:00.000Z",
+        "tag": "hash-string"
+      }
+    }
+  }
+}
+```
+
+**Existing task** continuation with slash commands (uses `event` wrapper):
+```json
+{
+  "event": {
+    "type": "user_message",
+    "content": "{{cmd:cmd1:tag1}} {{cmd:cmd2:tag2}}",
+    "timestamp": "2025-12-05T21:22:00.773Z",
+    "commands": {
+      "{{cmd:cmd1:tag1}}": { ... },
+      "{{cmd:cmd2:tag2}}": { ... }
+    }
+  }
+}
+```
+
 ### Resource Search
 - `GET /api/orgs/{org}/search/resourcesv2` - Search resources (v2 endpoint)
 - Pagination: `page` (1-based), `size` params

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,6 +11,6 @@ mod types;
 
 pub use client::PulumiClient;
 pub use types::{
-    EscEnvironmentSummary, NeoMessage, NeoMessageType, NeoTask, OrgStackUpdate, RegistryPackage,
-    RegistryTemplate, Resource, ResourceSummaryPoint, Service, Stack,
+    EscEnvironmentSummary, NeoMessage, NeoMessageType, NeoSlashCommand, NeoTask, OrgStackUpdate,
+    RegistryPackage, RegistryTemplate, Resource, ResourceSummaryPoint, Service, Stack,
 };

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -404,6 +404,65 @@ pub struct NeoTasksResponse {
     pub tasks: Vec<NeoTask>,
 }
 
+// ─────────────────────────────────────────────────────────────
+// Neo Slash Commands Types
+// ─────────────────────────────────────────────────────────────
+
+/// Neo Slash Command (available from /commands API)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoSlashCommand {
+    /// Command name (e.g., "get-started")
+    pub name: String,
+    /// Full prompt text to be sent
+    pub prompt: String,
+    /// Short description shown to user
+    pub description: String,
+    /// Whether this is a built-in command
+    #[serde(default)]
+    pub built_in: bool,
+    /// Last modified timestamp
+    #[serde(default)]
+    pub modified_at: Option<String>,
+    /// Unique tag/hash for this command version
+    #[serde(default)]
+    pub tag: Option<String>,
+}
+
+impl NeoSlashCommand {
+    /// Generate the command reference string for the API payload
+    /// Format: {{cmd:name:tag}}
+    pub fn command_reference(&self) -> String {
+        let tag = self.tag.as_deref().unwrap_or("");
+        format!("{{{{cmd:{}:{}}}}}", self.name, tag)
+    }
+}
+
+/// Message structure for creating a task (supports both plain text and commands)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoCreateTaskMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub content: String,
+    pub timestamp: String,
+    /// Commands map - only present when using slash commands
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commands: Option<std::collections::HashMap<String, NeoSlashCommandPayload>>,
+}
+
+/// Slash command data included in the payload
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeoSlashCommandPayload {
+    pub name: String,
+    pub prompt: String,
+    pub description: String,
+    pub built_in: bool,
+    pub modified_at: String,
+    pub tag: String,
+}
+
 /// Resource search result
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -48,6 +48,9 @@ struct AppState { stacks, environments, neo_tasks, resources, ... }
 | `neo_scroll_state` | ScrollViewState | Scroll position (tui-scrollview) |
 | `neo_auto_scroll` | Arc<AtomicBool> | Thread-safe auto-scroll toggle |
 | `neo_task_is_running` | bool | Task status is "running" |
+| `neo_show_command_picker` | bool | Show slash command picker popup |
+| `neo_filtered_commands` | Vec<NeoSlashCommand> | Filtered commands for picker |
+| `neo_command_picker_index` | usize | Selected command in picker |
 
 ## Neo Polling Mechanism
 
@@ -60,6 +63,7 @@ struct AppState { stacks, environments, neo_tasks, resources, ... }
 | Key | Action |
 |-----|--------|
 | `i` | Enter input mode |
+| `/` | Open slash command picker |
 | `n` | New task |
 | `d` | Task details dialog |
 | `j/k` | Scroll 3 lines |
@@ -67,6 +71,36 @@ struct AppState { stacks, environments, neo_tasks, resources, ... }
 | `g/G` | Jump to top/bottom |
 | `Enter` | Load selected task |
 | `Esc` | Show task list |
+
+## Neo Slash Commands
+
+Slash commands allow users to invoke predefined Neo prompts.
+
+### How it works
+1. Commands are fetched from `GET /api/console/agents/{org}/commands`
+2. When user types `/` in input, picker shows filtered commands
+3. User navigates with ↑/↓, selects with Enter or Tab to complete
+4. Sends to `POST /api/preview/agents/{org}/tasks` with command payload:
+   ```json
+   {
+     "message": {
+       "type": "user_message",
+       "content": "{{cmd:name:tag}}",
+       "timestamp": "...",
+       "commands": { "{{cmd:name:tag}}": { ... command details ... } }
+     }
+   }
+   ```
+
+### Input Mode Key Bindings (when picker showing)
+| Key | Action |
+|-----|--------|
+| `↑/↓` or `Ctrl+P/N` | Navigate commands |
+| `Tab` | Insert command into input |
+| `Enter` | Insert command into input |
+| `Esc` | Cancel picker |
+
+Note: Commands are inserted (not immediately executed) so users can add text or multiple commands before sending.
 
 ## Data Loading (data.rs)
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -4,8 +4,8 @@
 //! including enums for tabs, focus modes, and the main application state struct.
 
 use crate::api::{
-    EscEnvironmentSummary, NeoMessage, NeoTask, OrgStackUpdate, RegistryPackage, RegistryTemplate,
-    Resource, ResourceSummaryPoint, Service, Stack,
+    EscEnvironmentSummary, NeoMessage, NeoSlashCommand, NeoTask, OrgStackUpdate, RegistryPackage,
+    RegistryTemplate, Resource, ResourceSummaryPoint, Service, Stack,
 };
 
 /// Async data loading result
@@ -14,6 +14,7 @@ pub enum DataLoadResult {
     Stacks(Vec<Stack>),
     EscEnvironments(Vec<EscEnvironmentSummary>),
     NeoTasks(Vec<NeoTask>),
+    NeoSlashCommands(Vec<NeoSlashCommand>),
     Resources(Vec<Resource>),
     Services(Vec<Service>),
     RegistryPackages(Vec<RegistryPackage>),
@@ -214,6 +215,8 @@ pub struct AppState {
     // Neo conversation
     pub neo_messages: Vec<NeoMessage>,
     pub current_task_id: Option<String>,
+    /// Available slash commands from API
+    pub neo_slash_commands: Vec<NeoSlashCommand>,
 
     // Platform data
     pub services: Vec<Service>,
@@ -239,6 +242,7 @@ impl Default for AppState {
             selected_env_values: None,
             neo_messages: Vec::new(),
             current_task_id: None,
+            neo_slash_commands: Vec::new(),
             services: Vec::new(),
             registry_packages: Vec::new(),
             registry_templates: Vec::new(),


### PR DESCRIPTION
## Summary

- Add slash command picker UI with `/` key shortcut in Neo view
- Commands are fetched from Pulumi Cloud API (`/api/console/agents/{org}/commands`)
- Insert commands into input (don't execute immediately) - allows combining multiple commands or adding custom text
- Purple background highlighting for inserted commands in the input field
- Support slash commands in both new tasks (`message` wrapper) and task continuation (`event` wrapper)

## Changes

### API Client (`src/api/`)
- Add `NeoSlashCommand` type with `command_reference()` helper
- Add `get_neo_slash_commands()` to fetch available commands
- Add `create_neo_task_with_commands()` for new tasks with commands
- Add `continue_neo_task_with_commands()` for existing task continuation

### App State (`src/app/`)
- Add `neo_show_command_picker`, `neo_filtered_commands`, `neo_command_picker_index` for picker UI
- Add `neo_pending_commands` to track inserted commands before sending
- Update `send_neo_message()` to handle pending commands
- Add `insert_selected_slash_command()` and `update_filtered_commands()` methods

### UI (`src/ui/neo.rs`)
- Add `render_command_picker()` popup with command list and descriptions
- Add `render_input_with_commands()` with purple highlighting for slash commands
- Update input rendering to show pending commands visually

### Key Bindings
- `/` in Normal mode: Open slash command picker
- `↑/↓` or `Ctrl+P/N`: Navigate commands in picker
- `Enter` or `Tab`: Insert selected command
- `Esc`: Cancel picker

## Test plan

- [ ] Press `/` in Neo view to open command picker
- [ ] Navigate commands with arrow keys
- [ ] Press Enter or Tab to insert command
- [ ] Verify command appears with purple background
- [ ] Add additional text after command
- [ ] Insert multiple commands
- [ ] Send message and verify API receives correct payload
- [ ] Test slash commands in existing task continuation