### PR TITLE
feat: add GoReleaser Rust support with Homebrew cask

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: build-binary
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Check
+        run: cargo check
+
+      - name: Test
+        run: cargo test
+
+  release:
+    permissions:
+      contents: write
+      id-token: write
+    needs: build
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+    runs-on: ubuntu-latest
+    if: success() && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild
+        run: cargo install cargo-zigbuild
+
+      - name: Add Rust targets
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
+        with:
+          version: latest
+          args: release --clean

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/dist
 .env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: lazy-pulumi
+
+snapshot:
+  version_template: '{{ .Tag }}-SNAPSHOT'
+
+builds:
+  # Linux builds using cargo-zigbuild for cross-compilation
+  - id: lazy-pulumi-linux
+    builder: rust
+    binary: lazy-pulumi
+    command: zigbuild
+    flags:
+      - --release
+    targets:
+      - x86_64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
+
+  # macOS builds using cargo-zigbuild
+  - id: lazy-pulumi-darwin
+    builder: rust
+    binary: lazy-pulumi
+    command: zigbuild
+    flags:
+      - --release
+    targets:
+      - aarch64-apple-darwin
+      - x86_64-apple-darwin
+
+archives:
+  - format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+homebrew_casks:
+  - name: lazy-pulumi
+    repository:
+      owner: dirien
+      name: homebrew-dirien
+      branch: main
+
+    commit_author:
+      name: dirien
+      email: engin.diri@mail.schwarz
+
+    directory: Casks
+    homepage: "https://github.com/dirien/lazy-pulumi"
+    description: "A stylish TUI for Pulumi Cloud, ESC, and NEO"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^test:'
+      - '^chore'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+  groups:
+    - title: 'New Features'
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 10
+    - title: Other work
+      order: 999

--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ export PULUMI_ORG="your-org-name"
 export PULUMI_API_URL="https://api.pulumi.com"
 ```
 
-## Build & Run
+## Installation
+
+### Homebrew (macOS/Linux)
+
+```bash
+brew tap dirien/dirien
+brew install lazy-pulumi
+```
+
+### From Source
 
 ```bash
 # Build
@@ -48,6 +57,10 @@ cargo run --release
 # Run with debug logging
 RUST_LOG=debug cargo run --release
 ```
+
+### From Releases
+
+Download the latest binary from the [GitHub Releases](https://github.com/dirien/lazy-pulumi/releases) page.
 
 ## Logging
 


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yaml` with Rust builder using cargo-zigbuild for cross-compilation
- Configure builds for Linux (x86_64, aarch64) and macOS (x86_64, arm64)
- Add GitHub Actions workflow for automated releases on tag push
- Configure Homebrew cask publishing to `dirien/homebrew-dirien`
- Update README with installation instructions (Homebrew, source, releases)
- Add `/dist` to `.gitignore`

## Installation (after first release)

```bash
brew tap dirien/dirien
brew install lazy-pulumi
```

## Release Process

1. Create and push a tag: `git tag v0.1.0 && git push origin v0.1.0`
2. GitHub Actions will build binaries for all platforms
3. GoReleaser creates the release and updates the Homebrew tap

## Test Plan

- [x] `goreleaser check` validates configuration
- [x] `goreleaser release --snapshot --clean` builds successfully locally
- [ ] Tag push triggers release workflow