### PR TITLE
fix: use GITHUB_TOKEN instead of GH_PAT for GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     needs: build
     env:
-      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     if: success() && startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
## Summary
- Fixed GoReleaser release job failing with "missing GITHUB_TOKEN" error
- Changed from `secrets.GH_PAT` (not configured) to `secrets.GITHUB_TOKEN` (built-in)

## Test plan
- [ ] Merge and recreate v0.0.1 release to verify workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)