### PR TITLE
feat: use matrix build with native runners for cross-platform releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,15 +28,35 @@ jobs:
       - name: Test
         run: cargo test
 
-  release:
-    permissions:
-      contents: write
-      id-token: write
+  # Build binaries on native runners for each platform
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     needs: build
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: lazy-pulumi
+            asset_name: lazy-pulumi-linux-amd64
+
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact_name: lazy-pulumi
+            asset_name: lazy-pulumi-linux-arm64
+
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact_name: lazy-pulumi
+            asset_name: lazy-pulumi-darwin-amd64
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: lazy-pulumi
+            asset_name: lazy-pulumi-darwin-arm64
+
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -45,21 +65,52 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Zig
-        uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2.2.1
         with:
-          version: 0.13.0
+          targets: ${{ matrix.target }}
 
-      - name: Install cargo-zigbuild
-        run: cargo install cargo-zigbuild
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Add Rust targets
+      - name: Upload binary
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: ${{ matrix.asset_name }}
+          path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    permissions:
+      contents: write
+      id-token: write
+    needs: build-binaries
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: dist
+
+      - name: Prepare binaries for GoReleaser
         run: |
-          rustup target add x86_64-unknown-linux-gnu
-          rustup target add aarch64-unknown-linux-gnu
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-darwin
+          mkdir -p dist/lazy-pulumi_linux_amd64_v1
+          mkdir -p dist/lazy-pulumi_linux_arm64
+          mkdir -p dist/lazy-pulumi_darwin_amd64_v1
+          mkdir -p dist/lazy-pulumi_darwin_arm64
+
+          cp dist/lazy-pulumi-linux-amd64/lazy-pulumi dist/lazy-pulumi_linux_amd64_v1/
+          cp dist/lazy-pulumi-linux-arm64/lazy-pulumi dist/lazy-pulumi_linux_arm64/
+          cp dist/lazy-pulumi-darwin-amd64/lazy-pulumi dist/lazy-pulumi_darwin_amd64_v1/
+          cp dist/lazy-pulumi-darwin-arm64/lazy-pulumi dist/lazy-pulumi_darwin_arm64/
+
+          chmod +x dist/lazy-pulumi_*/lazy-pulumi
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,28 +8,21 @@ project_name: lazy-pulumi
 snapshot:
   version_template: '{{ .Tag }}-SNAPSHOT'
 
+# Use prebuilt binaries (built by GitHub Actions matrix)
 builds:
-  # Linux builds using cargo-zigbuild for cross-compilation
-  - id: lazy-pulumi-linux
-    builder: rust
+  - id: lazy-pulumi
+    builder: prebuilt
+    prebuilt:
+      path: dist/lazy-pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lazy-pulumi
     binary: lazy-pulumi
-    command: zigbuild
-    flags:
-      - --release
-    targets:
-      - x86_64-unknown-linux-gnu
-      - aarch64-unknown-linux-gnu
-
-  # macOS builds using cargo-zigbuild
-  - id: lazy-pulumi-darwin
-    builder: rust
-    binary: lazy-pulumi
-    command: zigbuild
-    flags:
-      - --release
-    targets:
-      - aarch64-apple-darwin
-      - x86_64-apple-darwin
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
 
 archives:
   - format_overrides:
@@ -39,6 +32,13 @@ archives:
 
 checksum:
   name_template: 'checksums.txt'
+
+universal_binaries:
+  - id: lazy-pulumi-universal
+    ids:
+      - lazy-pulumi
+    replace: true
+    name_template: lazy-pulumi
 
 homebrew_casks:
   - name: lazy-pulumi


### PR DESCRIPTION
## Summary
- Replaced cargo-zigbuild cross-compilation with native runner matrix builds
- Build binaries on actual macOS (Intel + ARM) and Linux (x86_64 + ARM64) runners
- Use GoReleaser `prebuilt` builder to package pre-compiled binaries
- Added universal binary support for macOS

## Why this change?
The previous approach using `cargo-zigbuild` to cross-compile from Linux failed because:
- The project links against macOS native frameworks (e.g., `CoreFoundation` from `ring` crate)
- Zig cannot link against Darwin frameworks without the macOS SDK installed
- Error: `unable to find framework 'CoreFoundation'. searched paths: none`

## New workflow
1. **build** job: Runs cargo check/test on Linux
2. **build-binaries** job: Matrix build on 4 native runners in parallel:
   - `ubuntu-latest` → `x86_64-unknown-linux-gnu`
   - `ubuntu-24.04-arm` → `aarch64-unknown-linux-gnu`  
   - `macos-13` → `x86_64-apple-darwin`
   - `macos-latest` → `aarch64-apple-darwin`
3. **release** job: Downloads all artifacts and uses GoReleaser to create release

## Test plan
- [ ] Merge and recreate v0.0.1 tag to trigger workflow
- [ ] Verify all 4 platform builds complete successfully
- [ ] Verify GoReleaser creates release with archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)