### PR TITLE
fix: use macos-15-intel runner for x86_64 macOS builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
             artifact_name: lazy-pulumi
             asset_name: lazy-pulumi-linux-arm64
 
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact_name: lazy-pulumi
             asset_name: lazy-pulumi-darwin-amd64


### PR DESCRIPTION
## Summary
- Changed macOS x86_64 build runner from `macos-13` to `macos-15-intel`
- The `macos-13` runner is retired as of December 2025

## Reference
- https://github.com/actions/runner-images/issues/13046

🤖 Generated with [Claude Code](https://claude.com/claude-code)