### PR TITLE
fix: use GoReleaser with native cargo builds and --single-target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Test
         run: cargo test
 
-  # Build binaries on native runners for each platform
+  # Build binaries on native runners using GoReleaser --single-target
   build-binaries:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -39,23 +39,15 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: lazy-pulumi
-            asset_name: lazy-pulumi-linux-amd64
 
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            artifact_name: lazy-pulumi
-            asset_name: lazy-pulumi-linux-arm64
 
           - os: macos-15-intel
             target: x86_64-apple-darwin
-            artifact_name: lazy-pulumi
-            asset_name: lazy-pulumi-darwin-amd64
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: lazy-pulumi
-            asset_name: lazy-pulumi-darwin-arm64
 
     steps:
       - name: Checkout
@@ -68,23 +60,25 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Run GoReleaser Build
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
+        with:
+          version: latest
+          args: build --single-target --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload binary
+      - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: ${{ matrix.asset_name }}
-          path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+          name: dist-${{ matrix.target }}
+          path: dist/
           if-no-files-found: error
 
   release:
     permissions:
       contents: write
-      id-token: write
     needs: build-binaries
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -96,24 +90,22 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          path: dist
+          path: artifacts
+          pattern: dist-*
+          merge-multiple: true
 
-      - name: Prepare binaries for GoReleaser
+      - name: Prepare dist folder
         run: |
-          mkdir -p dist/lazy-pulumi_linux_amd64_v1
-          mkdir -p dist/lazy-pulumi_linux_arm64
-          mkdir -p dist/lazy-pulumi_darwin_amd64_v1
-          mkdir -p dist/lazy-pulumi_darwin_arm64
+          mkdir -p dist
+          cp -r artifacts/* dist/ || true
+          find dist -type f -name "*.tar.gz" -o -name "*.zip" | head -20
+          ls -la dist/
 
-          cp dist/lazy-pulumi-linux-amd64/lazy-pulumi dist/lazy-pulumi_linux_amd64_v1/
-          cp dist/lazy-pulumi-linux-arm64/lazy-pulumi dist/lazy-pulumi_linux_arm64/
-          cp dist/lazy-pulumi-darwin-amd64/lazy-pulumi dist/lazy-pulumi_darwin_amd64_v1/
-          cp dist/lazy-pulumi-darwin-arm64/lazy-pulumi dist/lazy-pulumi_darwin_arm64/
-
-          chmod +x dist/lazy-pulumi_*/lazy-pulumi
-
-      - name: Run GoReleaser
+      - name: Run GoReleaser Release
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           version: latest
-          args: release --clean
+          args: release --clean --skip=build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,52 +8,29 @@ project_name: lazy-pulumi
 snapshot:
   version_template: '{{ .Tag }}-SNAPSHOT'
 
-# Use prebuilt binaries (built by GitHub Actions matrix)
 builds:
   - id: lazy-pulumi
-    builder: prebuilt
-    prebuilt:
-      path: dist/lazy-pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lazy-pulumi
+    builder: rust
     binary: lazy-pulumi
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    goamd64:
-      - v1
+    # Use cargo directly (not zigbuild) - builds natively on each runner
+    tool: cargo
+    command: build
+    flags:
+      - --release
+    targets:
+      - x86_64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
 
 archives:
-  - format_overrides:
+  - format: tar.gz
+    format_overrides:
       - goos: windows
-        formats:
-          - zip
+        format: zip
 
 checksum:
   name_template: 'checksums.txt'
-
-universal_binaries:
-  - id: lazy-pulumi-universal
-    ids:
-      - lazy-pulumi
-    replace: true
-    name_template: lazy-pulumi
-
-homebrew_casks:
-  - name: lazy-pulumi
-    repository:
-      owner: dirien
-      name: homebrew-dirien
-      branch: main
-
-    commit_author:
-      name: dirien
-      email: engin.diri@mail.schwarz
-
-    directory: Casks
-    homepage: "https://github.com/dirien/lazy-pulumi"
-    description: "A stylish TUI for Pulumi Cloud, ESC, and NEO"
 
 changelog:
   sort: asc
@@ -74,3 +51,20 @@ changelog:
       order: 10
     - title: Other work
       order: 999
+
+# Homebrew Cask for macOS distribution
+homebrew_casks:
+  - name: lazy-pulumi
+    repository:
+      owner: dirien
+      name: homebrew-dirien
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+
+    commit_author:
+      name: dirien
+      email: engin.diri@mail.schwarz
+
+    directory: Casks
+    homepage: "https://github.com/dirien/lazy-pulumi"
+    description: "A stylish TUI for Pulumi Cloud, ESC, and NEO"


### PR DESCRIPTION
## Summary
- Use GoReleaser's Rust builder with `tool: cargo` instead of `zigbuild`
- Build on native runners (Linux, macOS Intel, macOS ARM) with `--single-target` flag
- Combine all artifacts and release with `--skip=build`
- Re-add Homebrew Cask support for macOS distribution

## Why this change?
`cargo-zigbuild` cannot cross-compile for macOS from Linux when the project links against native frameworks like `CoreFoundation` (from the `ring` crate).

This approach:
1. Builds natively on each platform using `goreleaser build --single-target`
2. Uploads artifacts from each runner
3. Downloads all artifacts and runs `goreleaser release --skip=build` to create archives, checksums, and Homebrew Cask

## Test plan
- [ ] Merge and recreate v0.0.1 tag to verify workflow completes
- [ ] Verify Homebrew Cask is updated in `dirien/homebrew-dirien`