### PR TITLE
fix: default empty cwd field to current working directory

### DIFF
--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -739,15 +739,17 @@ impl CommandExecution {
         }
     }
 
-    /// Get the working directory if specified (cwd parameter is handled separately)
+    /// Get the working directory (defaults to current directory if empty or unspecified)
     pub fn get_working_directory(&self) -> Option<String> {
-        self.param_values.get("cwd").and_then(|v| {
-            if v.is_empty() {
-                None
-            } else {
-                Some(v.clone())
-            }
-        })
+        self.param_values
+            .get("cwd")
+            .filter(|v| !v.is_empty())
+            .map(|v| v.clone())
+            .or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .and_then(|p| p.to_str().map(|s| s.to_string()))
+            })
     }
 
     /// Build the full command line arguments


### PR DESCRIPTION
## Summary
- Fix issue where leaving the `cwd` field empty in the command tab didn't default to the current directory
- The `get_working_directory()` method now uses `std::env::current_dir()` when the cwd parameter is empty or unspecified

## Test plan
- [ ] Open the command tab
- [ ] Leave the `cwd` field empty and run a command
- [ ] Verify the command runs in the current working directory
- [ ] Enter `.` explicitly and verify the same behavior

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)