### PR TITLE
fix(ci): migrate homebrew from brews to homebrew_casks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          version: latest
+          version: "~> v2.10"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
@@ -79,7 +79,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          version: latest
+          version: "~> v2.10"
           args: release --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
-brews:
+homebrew_casks:
   - name: lazy-pulumi
     repository:
       owner: dirien
@@ -61,12 +61,16 @@ brews:
       name: dirien
       email: engin.diri@mail.schwarz
 
-    directory: Formula
+    directory: Casks
     homepage: "https://github.com/dirien/lazy-pulumi"
     description: "A stylish TUI for Pulumi Cloud, ESC, and NEO"
-    license: "MIT"
-    install: |
-      bin.install "lazy-pulumi"
+
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/lazy-pulumi"]
+          end
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
- Migrate GoReleaser config from deprecated `brews` (Formulas) to `homebrew_casks` (Casks), aligning with GoReleaser v2.10+ changes
- Pin GoReleaser version to `~> v2.10` instead of `latest` to prevent future silent breakage
- Add macOS quarantine removal hook for unsigned binaries

## Context
GoReleaser v2.10 deprecated `brews` in favor of `homebrew_casks`. Using `version: latest` in CI caused the v0.8.0 release to create a Cask in `Casks/` instead of updating the existing Formula in `Formula/`. The old Formula has been removed from the homebrew tap.

Install command is now: `brew install --cask dirien/dirien/lazy-pulumi`

## Test plan
- [ ] Tag a new release and verify GoReleaser publishes to `Casks/lazy-pulumi.rb` in the homebrew tap
- [ ] Verify `brew install --cask dirien/dirien/lazy-pulumi` works
- [ ] Verify `brew upgrade --cask lazy-pulumi` works for existing installs