### PR TITLE
docs: update README for homebrew cask install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ export PULUMI_API_URL="https://api.pulumi.com"
 
 ## Installation
 
-### Homebrew (macOS/Linux)
+### Homebrew (macOS)
 
 ```bash
 brew tap dirien/dirien
-brew install lazy-pulumi
+brew install --cask lazy-pulumi
 ```
 
 ### From Source
@@ -69,13 +69,7 @@ Download the latest binary from the [GitHub Releases](https://github.com/dirien/
 To update to the latest version via Homebrew:
 
 ```bash
-brew update && brew upgrade lazy-pulumi
-```
-
-Or update all Homebrew packages including lazy-pulumi:
-
-```bash
-brew update && brew upgrade
+brew update && brew upgrade --cask lazy-pulumi
 ```
 
 ## Logging


### PR DESCRIPTION
## Summary
- Update install command from `brew install` to `brew install --cask` after the Formula → Cask migration in #72
- Update upgrade command to use `--cask` flag
- Change "macOS/Linux" to "macOS" since Casks are macOS-only

## Test plan
- [ ] Verify `brew tap dirien/dirien && brew install --cask lazy-pulumi` works after next release
- [ ] Verify `brew update && brew upgrade --cask lazy-pulumi` works for upgrades