### PR TITLE
chore(api): update OpenAPI spec and adapt tests to new required fields

### DIFF
--- a/openapi/pulumi-spec.json
+++ b/openapi/pulumi-spec.json
@@ -208,6 +208,27 @@
             "$ref": "#/components/schemas/AccessTokenRole",
             "description": "Role associated with the token, if applicable",
             "x-order": 9
+          },
+          "type": {
+            "description": "The token's kind.",
+            "enum": [
+              "personal",
+              "refresh",
+              "organization",
+              "team"
+            ],
+            "type": "string",
+            "x-order": 10,
+            "x-pulumi-model-property": {
+              "enumComments": "The kind of an access token returned by the access-tokens APIs.",
+              "enumFieldComments": [
+                "A personal access token created by a user.",
+                "A refresh token, exchanged for short-lived OBO access tokens at /api/oauth/token. Not authorized for any other endpoint.",
+                "A machine token bound to an organization's robot user.",
+                "A machine token bound to a team's robot user within an organization."
+              ],
+              "enumTypeName": "AccessTokenType"
+            }
           }
         },
         "required": [
@@ -298,11 +319,44 @@
         },
         "type": "object"
       },
+      "AddChangeRequestCommentRequest": {
+        "description": "AddChangeRequestCommentRequest adds a comment to a change request without approving or closing it.",
+        "properties": {
+          "comment": {
+            "description": "The comment text to add to the change request.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "comment"
+        ],
+        "type": "object"
+      },
+      "AddCustomVCSRepositoryRequest": {
+        "description": "Request to add a repository to a custom VCS integration. The repository name must be unique within the integration; adding a duplicate name returns 409 Conflict.",
+        "properties": {
+          "displayName": {
+            "description": "Human-readable display name for the repository. If not provided, the name is used for display purposes.",
+            "type": "string",
+            "x-order": 2
+          },
+          "name": {
+            "description": "Repository name or path, joined with the integration's base URL to form the clone URL (e.g. 'myrepo' or 'subgroup/myrepo')",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
       "AddOrganizationMemberRequest": {
         "description": "AddOrganizationMemberRequest is the request type for adding a new member to an organization.",
         "properties": {
           "role": {
-            "description": "Role is the role assigned to the new member. Must be one of MEMBER, ADMIN, or BILLING MANAGER.",
+            "description": "The built-in role assigned to the new member. Must be `member`, `admin`, or `billingManager`.",
             "enum": [
               "none",
               "member",
@@ -377,6 +431,33 @@
         ],
         "type": "object"
       },
+      "AgentAccountSummary": {
+        "description": "Identity and metadata for an agent's Pulumi account, returned as part of AgentClaimResponse so the claiming user can confirm which agent they are taking over.",
+        "properties": {
+          "createdAt": {
+            "description": "When the agent account was created (i.e. when /api/agents/signup ran).",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 3
+          },
+          "login": {
+            "description": "The agent user's Pulumi login (e.g. \"agent-abc123\"). This is what pulumi whoami returns while the agent's access token is in use.",
+            "type": "string",
+            "x-order": 1
+          },
+          "orgName": {
+            "description": "Slug of the agent's individual organization. This appears in the <org>/<project>/<stack> identity of any stack the agent created.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "createdAt",
+          "login",
+          "orgName"
+        ],
+        "type": "object"
+      },
       "AgentBackendEvent": {
         "description": "An event sent from the agent backend to the client during an agent task execution.",
         "discriminator": {
@@ -430,6 +511,14 @@
                 "description": "Whether this is the final message in the response.",
                 "type": "boolean",
                 "x-order": 3
+              },
+              "thinking_signatures": {
+                "description": "Opaque thinking-block signatures from the model's response, in order. Must be echoed back unchanged on subsequent API calls to preserve reasoning across tool-use turns when extended thinking is enabled. Empty/null for models or turns without extended thinking. With display:\"omitted\" (Opus 4.7 default) the thinking text itself is empty; only the signature carries load.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-order": 5
               },
               "token_usage": {
                 "additionalProperties": {
@@ -720,6 +809,20 @@
             "type": "object",
             "x-order": 3
           },
+          "execution_mode": {
+            "description": "Where this specific tool call must be executed. Omitted means the task default applies ('cloud' unless the task was created with 'cli'). When set to 'cli' or 'worker', the agent's turn ends with the containing assistant message (is_final=true) and an external executor must run this tool call and reply with a ToolResult user event to resume the turn: 'cli' is a real local `pulumi neo` client, 'worker' is a managed worker the service launches. Different tool calls within the same assistant message may independently target 'cloud', 'cli', or 'worker'.",
+            "enum": [
+              "cloud",
+              "cli",
+              "worker"
+            ],
+            "type": "string",
+            "x-order": 4,
+            "x-pulumi-model-property": {
+              "enumComments": "Where tools are executed for an agent task.",
+              "enumTypeName": "ToolExecutionMode"
+            }
+          },
           "id": {
             "description": "Tool call identifier.",
             "type": "string",
@@ -913,6 +1016,98 @@
           }
         ]
       },
+      "AgentClaimRequest": {
+        "description": "Details for claiming the resources created by an agent account.",
+        "properties": {
+          "claimToken": {
+            "description": "The opaque single-use claim token embedded in the claim URL the agent surfaces to its human. Returned by /api/agents/signup as part of the claim URL.",
+            "type": "string",
+            "x-order": 1
+          },
+          "conflictsResolution": {
+            "description": "Renaming instructions for the entities flagged in the response's conflicts list. Failures cannot be resolved this way.",
+            "items": {
+              "$ref": "#/components/schemas/TransferEntity"
+            },
+            "type": "array",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "claimToken"
+        ],
+        "type": "object"
+      },
+      "AgentClaimResponse": {
+        "description": "Describes an agent account being claimed: the agent itself, the inventory of Pulumi entities it owns in the source organization, and the conflicts or failures that prevent the claim from completing. Preview and commit share this shape so the UI can render the same view for both.",
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentAccountSummary",
+            "description": "Identity and metadata for the agent account being claimed.",
+            "x-order": 1
+          },
+          "claimExpiresAt": {
+            "description": "When the claim window closes. After this time the claim token expires and the claim cannot complete.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 5
+          },
+          "conflicts": {
+            "description": "Name collisions with the destination organization that the client can resolve by supplying conflictsResolution in a follow-up request. Both preview and a blocked commit return 200 with this body populated; the commit does not mutate state when any conflict is present.",
+            "items": {
+              "$ref": "#/components/schemas/TransferEntity"
+            },
+            "type": "array",
+            "x-order": 3
+          },
+          "entities": {
+            "description": "Inventory of Pulumi entities owned by the agent in the source organization. If the claim completes, these transfer to the destination organization. A non-empty conflicts or failures list prevents the claim from completing.",
+            "items": {
+              "$ref": "#/components/schemas/TransferEntity"
+            },
+            "type": "array",
+            "x-order": 2
+          },
+          "failures": {
+            "description": "Entities the service cannot transfer (e.g. Insights accounts at launch, which have no transfer primitive yet). Unlike conflicts, failures are not user-resolvable.",
+            "items": {
+              "$ref": "#/components/schemas/TransferEntityFailure"
+            },
+            "type": "array",
+            "x-order": 4
+          },
+          "transferToken": {
+            "description": "On successful start of a claim, the token needed to check for progress.",
+            "type": "string",
+            "x-order": 6
+          }
+        },
+        "required": [
+          "agent",
+          "claimExpiresAt",
+          "conflicts",
+          "entities",
+          "failures"
+        ],
+        "type": "object"
+      },
+      "AgentClaimsStatus": {
+        "description": "Status of recent agent claims for an organization, keyed by claim identifier.",
+        "properties": {
+          "claims": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AgentClaimResponse"
+            },
+            "description": "The set of recent agent claims.",
+            "type": "object",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "claims"
+        ],
+        "type": "object"
+      },
       "AgentConsoleEvent": {
         "description": "A console event in an agent task conversation, either a user input or an agent response.",
         "discriminator": {
@@ -928,12 +1123,18 @@
             "type": "string",
             "x-order": 1
           },
+          "isSynthetic": {
+            "description": "True when the event was synthesized by the backend rather than submitted directly by the user or agent runtime.",
+            "type": "boolean",
+            "x-order": 2
+          },
           "type": {
             "type": "string"
           }
         },
         "required": [
           "id",
+          "isSynthetic",
           "type"
         ],
         "type": "object"
@@ -1168,6 +1369,11 @@
             "type": "string",
             "x-order": 2
           },
+          "isDefault": {
+            "description": "Whether this pool is the organization's default workflow runner pool.",
+            "type": "boolean",
+            "x-order": 8
+          },
           "lastDeployment": {
             "description": "Unix epoch timestamp (seconds) of the most recent deployment executed by this pool. Null if no deployments have run.",
             "format": "int64",
@@ -1203,6 +1409,7 @@
           "created",
           "description",
           "id",
+          "isDefault",
           "lastSeen",
           "name",
           "status"
@@ -1262,6 +1469,86 @@
         },
         "type": "object"
       },
+      "AgentSignupChallenge": {
+        "description": "Returned from GET /api/agents/signup/challenge. Carries the input data the caller computes the proof of work over, plus an opaque ID identifying this challenge for the subsequent POST /api/agents/signup call.",
+        "properties": {
+          "challengeData": {
+            "description": "Input data for the proof-of-work computation. Compute the proof over this and submit the result to POST /api/agents/signup as challengeResult.",
+            "type": "string",
+            "x-order": 2
+          },
+          "challengeID": {
+            "description": "An ID identifying this challenge. Pass back to POST /api/agents/signup as challengeID.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "challengeData",
+          "challengeID"
+        ],
+        "type": "object"
+      },
+      "AgentSignupRequest": {
+        "description": "POST /api/agents/signup request body. Both fields come from the prior call to GET /api/agents/signup/challenge (which returned the challengeID and challengeData); the caller computes the proof of work over the challengeData and submits the result here.",
+        "properties": {
+          "challengeID": {
+            "description": "An ID identifying the challenge issued by GET /api/agents/signup/challenge.",
+            "type": "string",
+            "x-order": 1
+          },
+          "challengeResult": {
+            "description": "Output of the proof-of-work computation over the challengeData returned by GET /api/agents/signup/challenge.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "challengeID",
+          "challengeResult"
+        ],
+        "type": "object"
+      },
+      "AgentSignupResponse": {
+        "description": "Returned from POST /api/agents/signup. Contains the newly-created agent user's profile, an access token the CLI persists for future API calls, and an opaque claim token the human submits to take ownership of the account.",
+        "properties": {
+          "accessToken": {
+            "description": "The Pulumi access token to use for authenticating future API requests as the new user.",
+            "type": "string",
+            "x-order": 1
+          },
+          "accessTokenValidUntil": {
+            "description": "When the temporary access token expires.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 2
+          },
+          "claimToken": {
+            "description": "An opaque single-use token the human submits to claim ownership of the account. The CLI surfaces a claim URL embedding this token to the human; the path is a CLI/UI concern.",
+            "type": "string",
+            "x-order": 3
+          },
+          "claimTokenValidUntil": {
+            "description": "When the claim token expires.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 4
+          },
+          "userInfo": {
+            "$ref": "#/components/schemas/User",
+            "description": "The newly-created user's profile information.",
+            "x-order": 5
+          }
+        },
+        "required": [
+          "accessToken",
+          "accessTokenValidUntil",
+          "claimToken",
+          "claimTokenValidUntil",
+          "userInfo"
+        ],
+        "type": "object"
+      },
       "AgentSlashCommand": {
         "description": "An agent slash command.",
         "properties": {
@@ -1318,22 +1605,61 @@
               "balanced"
             ],
             "type": "string",
-            "x-order": 5,
+            "x-order": 7,
             "x-pulumi-model-property": {
               "enumComments": "NeoApprovalMode represents the default approval mode for Neo AI agent tasks in an organization",
               "enumTypeName": "NeoApprovalMode"
             }
           },
+          "asyncTriggerType": {
+            "description": "The async trigger source for this task. Null for sync tasks.",
+            "enum": [
+              "scheduled",
+              "external_signal"
+            ],
+            "type": "string",
+            "x-order": 4,
+            "x-pulumi-model-property": {
+              "enumComments": "The async trigger source for a Neo agent task.",
+              "enumFieldComments": [
+                "The task was started by a cron-driven scheduled signal.",
+                "The task was started in reaction to an external signal payload."
+              ],
+              "enumFieldNames": [
+                "Scheduled",
+                "ExternalSignal"
+              ],
+              "enumTypeName": "AgentAsyncTriggerType"
+            }
+          },
+          "contextCompactionThresholdPercent": {
+            "description": "Percentage of the context window (1-100) at which the agent triggers conversation compaction. Populated alongside contextWindowTokens when token usage data is available; omitted otherwise.",
+            "format": "int32",
+            "type": "integer",
+            "x-order": 19
+          },
+          "contextUsedTokens": {
+            "description": "Total input tokens consumed across all model invocations for this task. Approximate context window usage.",
+            "format": "int32",
+            "type": "integer",
+            "x-order": 17
+          },
+          "contextWindowTokens": {
+            "description": "Maximum context window size in tokens for the primary model used by this task.",
+            "format": "int32",
+            "type": "integer",
+            "x-order": 18
+          },
           "createdAt": {
             "description": "When the task was created, in ISO 8601 format.",
             "format": "date-time",
             "type": "string",
-            "x-order": 4
+            "x-order": 6
           },
           "createdBy": {
             "$ref": "#/components/schemas/UserInfo",
             "description": "Information about the user who created this task.",
-            "x-order": 10
+            "x-order": 12
           },
           "entities": {
             "description": "Pulumi entities (stacks, projects, etc.) that provide context for the agent.",
@@ -1341,7 +1667,7 @@
               "$ref": "#/components/schemas/AgentEntity"
             },
             "type": "array",
-            "x-order": 6
+            "x-order": 8
           },
           "id": {
             "description": "Unique identifier for the task.",
@@ -1351,7 +1677,13 @@
           "isShared": {
             "description": "Whether this task is shared with other org members.",
             "type": "boolean",
-            "x-order": 8
+            "x-order": 10
+          },
+          "lastHeartbeat": {
+            "description": "When the task runtime last reported a heartbeat. Null if the runtime has never checked in.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 16
           },
           "name": {
             "description": "Display name for the task, typically auto-generated from the initial user message.",
@@ -1365,7 +1697,7 @@
               "read-only"
             ],
             "type": "string",
-            "x-order": 11,
+            "x-order": 13,
             "x-pulumi-model-property": {
               "enumComments": "Permission scope for a Neo agent task. Controls the level of access the agent has when acting on behalf of the user.",
               "enumFieldNames": [
@@ -1378,13 +1710,73 @@
           "planMode": {
             "description": "Whether the task is in plan mode. Set based on the first user message.",
             "type": "boolean",
-            "x-order": 7
+            "x-order": 9
+          },
+          "role": {
+            "description": "The id of the RBAC role this task assumes. Null when the task runs with the creating user's own permissions (no assumed role).",
+            "type": "string",
+            "x-order": 14
+          },
+          "runtimePhase": {
+            "description": "The current runtime phase for this task. Null until the runtime checks in.",
+            "enum": [
+              "booting",
+              "ready",
+              "running"
+            ],
+            "type": "string",
+            "x-order": 15,
+            "x-pulumi-model-property": {
+              "enumComments": "Runtime lifecycle phase for a Neo agent task runtime.",
+              "enumTypeName": "AgentTaskRuntimePhase"
+            }
           },
           "sharedAt": {
             "description": "When the task was first shared. Null if never shared.",
             "format": "date-time",
             "type": "string",
-            "x-order": 9
+            "x-order": 11
+          },
+          "source": {
+            "description": "The origin that triggered this task. Valid values: 'console', 'cli', 'slack', 'schedule', 'api', 'github', 'code-review'.",
+            "enum": [
+              "api",
+              "console",
+              "cli",
+              "slack",
+              "schedule",
+              "github",
+              "code-review"
+            ],
+            "type": "string",
+            "x-order": 23,
+            "x-pulumi-model-property": {
+              "enumComments": "Identifies the origin that triggered a Neo agent task.",
+              "enumFieldComments": [
+                "Task created via the REST API without a more specific origin.",
+                "Task created from the Pulumi Cloud web console.",
+                "Task created from the Pulumi CLI.",
+                "Task created from the Slack integration.",
+                "Task created by a scheduled automation.",
+                "Task triggered from a GitHub integration.",
+                "Task created by the code review feature. The platform hosting the reviewed change is identified by the task's vcsProvider field."
+              ],
+              "enumFieldNames": [
+                "Api",
+                "Console",
+                "Cli",
+                "Slack",
+                "Schedule",
+                "Github",
+                "CodeReview"
+              ],
+              "enumTypeName": "AgentTaskSource"
+            }
+          },
+          "sourceAutomationID": {
+            "description": "The automation that spawned this task, if the task was created by an automation run.",
+            "type": "string",
+            "x-order": 22
           },
           "status": {
             "description": "Current execution status of the task.",
@@ -1393,10 +1785,80 @@
               "idle"
             ],
             "type": "string",
-            "x-order": 3,
+            "x-order": 5,
             "x-pulumi-model-property": {
               "enumComments": "Execution status of an agent task. Valid values: 'running', 'idle'.",
               "enumTypeName": "AgentTaskStatus"
+            }
+          },
+          "taskType": {
+            "description": "Whether the task was started synchronously by a user or asynchronously by background automation.",
+            "enum": [
+              "sync",
+              "async"
+            ],
+            "type": "string",
+            "x-order": 3,
+            "x-pulumi-model-property": {
+              "enumComments": "The origin category for a Neo agent task.",
+              "enumFieldComments": [
+                "A task started directly by a user in an interactive flow.",
+                "A task started asynchronously by background signal infrastructure."
+              ],
+              "enumTypeName": "AgentTaskType"
+            }
+          },
+          "tokensUsed": {
+            "description": "Total Neo tokens consumed across all model invocations for this task. Neo tokens are the priced unit used for billing — distinct from the raw model input tokens surfaced in contextUsedTokens / contextWindowTokens.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 20
+          },
+          "toolExecutionMode": {
+            "description": "Where tools are executed for this task. Valid values: 'cloud', 'cli'.",
+            "enum": [
+              "cloud",
+              "cli",
+              "worker"
+            ],
+            "type": "string",
+            "x-order": 21,
+            "x-pulumi-model-property": {
+              "enumComments": "Where tools are executed for an agent task.",
+              "enumTypeName": "ToolExecutionMode"
+            }
+          },
+          "vcsProvider": {
+            "description": "The version control system this task operates against. Set for tasks that target a specific VCS platform (e.g. code reviews). Null for tasks with no VCS context.",
+            "enum": [
+              "github",
+              "gitlab",
+              "bitbucket",
+              "azure_devops",
+              "custom",
+              "github_enterprise"
+            ],
+            "type": "string",
+            "x-order": 24,
+            "x-pulumi-model-property": {
+              "enumComments": "VCSProvider describes an external version control system used by the Pulumi Service.",
+              "enumFieldComments": [
+                "GitHub version control system",
+                "GitLab version control system",
+                "Bitbucket version control system",
+                "Azure DevOps version control system",
+                "Custom version control system",
+                "GitHub Enterprise Server version control system"
+              ],
+              "enumFieldNames": [
+                "GitHub",
+                "GitLab",
+                "Bitbucket",
+                "AzureDevOps",
+                "Custom",
+                "GitHubEnterprise"
+              ],
+              "enumTypeName": "VCSProvider"
             }
           }
         },
@@ -1409,7 +1871,23 @@
           "isShared",
           "name",
           "planMode",
-          "status"
+          "status",
+          "taskType",
+          "tokensUsed"
+        ],
+        "type": "object"
+      },
+      "AgentTaskIntegrationRef": {
+        "description": "A reference to an integration enabled for an agent task. Structured as an object (rather than a bare string) so additional fields like instance name or scope can be added later without breaking the wire format.",
+        "properties": {
+          "id": {
+            "description": "The catalog integration ID (e.g. 'honeycomb', 'datadog').",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "id"
         ],
         "type": "object"
       },
@@ -1417,6 +1895,8 @@
         "description": "Represents an agent user event.",
         "discriminator": {
           "mapping": {
+            "exec_tool_call": "#/components/schemas/AgentUserEventExecToolCall",
+            "tool_result": "#/components/schemas/AgentUserEventToolResult",
             "user_cancel": "#/components/schemas/AgentUserEventCancel",
             "user_confirmation": "#/components/schemas/AgentUserEventConfirmation",
             "user_message": "#/components/schemas/AgentUserEventMessage"
@@ -1428,6 +1908,11 @@
             "$ref": "#/components/schemas/AgentEntityDiff",
             "description": "Entities to add or remove from the agent.",
             "x-order": 1
+          },
+          "pageContext": {
+            "$ref": "#/components/schemas/PageContext",
+            "description": "Optional Pulumi Cloud page the user has the Neo pane open on at the moment they sent this event. Persisted with the event so cold-start replay can reproduce per-turn page context exactly. Omitted by clients with no concept of a current page (CLI, scheduled tasks, Slack, GitHub triggers, API consumers).",
+            "x-order": 2
           },
           "timestamp": {
             "description": "When the event occurred.",
@@ -1487,6 +1972,33 @@
           }
         ]
       },
+      "AgentUserEventExecToolCall": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentUserEvent"
+          },
+          {
+            "description": "Notification from the CLI client that it is about to execute a tool call locally. Sent before each tool call from a prior AssistantMessage with execution_mode=cli, so the service can record a corresponding exec_tool_call backend event and the UI can render a running tool entry while the CLI executes it.",
+            "properties": {
+              "name": {
+                "description": "Tool name.",
+                "type": "string",
+                "x-order": 2
+              },
+              "tool_call_id": {
+                "description": "Tool call identifier, correlating to a tool call from a prior AssistantMessage with execution_mode=cli.",
+                "type": "string",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "name",
+              "tool_call_id"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "AgentUserEventMessage": {
         "allOf": [
           {
@@ -1516,10 +2028,66 @@
           }
         ]
       },
+      "AgentUserEventToolResult": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentUserEvent"
+          },
+          {
+            "description": "Batch of tool results delivered back to the agent. Sent by the CLI client after it executes tool calls from a prior AssistantMessage that had execution_mode=cli, resuming the agent's turn.",
+            "properties": {
+              "tool_results": {
+                "description": "Batch of tool results from CLI-side execution.",
+                "items": {
+                  "$ref": "#/components/schemas/AgentUserEventToolResultItem"
+                },
+                "type": "array",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "tool_results"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "AgentUserEventToolResultItem": {
+        "description": "A single tool result delivered back to the agent from the CLI client.",
+        "properties": {
+          "content": {
+            "description": "The result content from tool execution.",
+            "type": "object",
+            "x-order": 3
+          },
+          "is_error": {
+            "description": "Whether the tool execution resulted in an error.",
+            "type": "boolean",
+            "x-order": 4
+          },
+          "name": {
+            "description": "Tool name.",
+            "type": "string",
+            "x-order": 2
+          },
+          "tool_call_id": {
+            "description": "Tool call identifier, correlating to a tool call from a prior AssistantMessage with execution_mode=cli.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "content",
+          "name",
+          "tool_call_id"
+        ],
+        "type": "object"
+      },
       "AgentWorkflowDefinition": {
         "description": "Defines an agent workflow.",
         "properties": {
           "deploymentID": {
+            "deprecated": true,
             "description": "Deprecated: use typeSpecificID instead.",
             "type": "string",
             "x-order": 4
@@ -1805,7 +2373,9 @@
               "copilot-summarize-error",
               "copilot-explain-preview",
               "deployment-schema-version",
-              "stack-policy-packs"
+              "stack-policy-packs",
+              "api-version",
+              "neo-cli-mode"
             ],
             "type": "string",
             "x-order": 1,
@@ -1818,7 +2388,9 @@
                 "Indicates whether the service supports summarizing errors via Copilot.",
                 "Indicates whether the service supports the Copilot explainer.",
                 "Indicates the maximum deployment schema version that the service supports.",
-                "Indicates whether the service supports retrieving a stack's required policy packs."
+                "Indicates whether the service supports retrieving a stack's required policy packs.",
+                "Advertises the REST API versions (the `Accept: application/vnd.pulumi+N` header) that the service supports. The configuration object carries `maxVersion`, `minVersion`, and `defaultVersion`.",
+                "Advertises that the service supports Neo CLI mode. The configuration object carries `minCliVersion`, the minimum `pulumi` CLI semver required to start a Neo CLI session."
               ],
               "enumFieldNames": [
                 "DeltaCheckpointUploads",
@@ -1827,7 +2399,9 @@
                 "CopilotSummarizeError",
                 "CopilotExplainPreview",
                 "DeploymentSchemaVersion",
-                "StackPolicyPacks"
+                "StackPolicyPacks",
+                "APIVersion",
+                "NeoCLIMode"
               ],
               "enumTypeName": "AppAPICapability"
             }
@@ -2090,7 +2664,7 @@
             },
             "description": "Metadata contains optional data about the environment performing the publish operation,\ne.g. the current source code control commit information.",
             "type": "object",
-            "x-order": 10
+            "x-order": 11
           },
           "name": {
             "description": "Name is a unique URL-safe identifier (at the org level) for the package.\nIf the name has already been used by the organization, then the request will\ncreate a new version of the Policy Pack (incremented by one). This is supplied\nby the CLI.",
@@ -2119,6 +2693,11 @@
             "description": "A URL to the repository where the policy pack is defined.",
             "type": "string",
             "x-order": 9
+          },
+          "runtime": {
+            "description": "Analyzer SDK runtime that produced the pack (e.g. \"nodejs\", \"python\", \"opa\"). When both the existing pack and the incoming request specify a runtime, publishing a new version with a different runtime is rejected to avoid overwriting behavior. If either side is omitted (older CLIs that do not report a runtime, or packs published before this field existed), the runtime check is skipped.",
+            "type": "string",
+            "x-order": 10
           },
           "tags": {
             "description": "Tags for this policy pack.",
@@ -2175,11 +2754,11 @@
         "properties": {
           "config": {
             "$ref": "#/components/schemas/AppStackConfig",
-            "description": "The configuration",
+            "description": "The configuration for the new stack.",
             "x-order": 5
           },
           "stackName": {
-            "description": "The rest of the StackIdentifier (e.g. organization, project) is in the URL.",
+            "description": "The name of the stack being created.",
             "type": "string",
             "x-order": 1
           },
@@ -2212,6 +2791,16 @@
       },
       "AppCreateStackResponse": {
         "description": "CreateStackResponse is the response from a create Stack request.",
+        "properties": {
+          "messages": {
+            "description": "Messages is a list of messages that should be displayed to the user.",
+            "items": {
+              "$ref": "#/components/schemas/AppMessage"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
         "type": "object"
       },
       "AppDecryptValueRequest": {
@@ -2253,6 +2842,14 @@
       "AppDeploymentV3": {
         "description": "DeploymentV3 is the third version of the Deployment. It contains newer versions of the\nResource and Operation API types and a placeholder for a stack's secrets configuration.\nNote that both deployment schema versions 3 and 4 can be unmarshaled into DeploymentV3.",
         "properties": {
+          "extensions": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AppExtension"
+            },
+            "description": "Extensions is a map of extension blobs keyed by extension reference.",
+            "type": "object",
+            "x-order": 7
+          },
           "manifest": {
             "$ref": "#/components/schemas/AppManifestV1",
             "description": "Manifest contains metadata about this deployment.",
@@ -2283,6 +2880,14 @@
             "$ref": "#/components/schemas/AppSecretsProvidersV1",
             "description": "SecretsProviders is a placeholder for secret provider configuration.",
             "x-order": 2
+          },
+          "snippets": {
+            "description": "Snippets are the PCL snippets associated with this snapshot.",
+            "items": {
+              "$ref": "#/components/schemas/AppSnippetV1"
+            },
+            "type": "array",
+            "x-order": 6
           }
         },
         "required": [
@@ -2511,6 +3116,36 @@
         ],
         "type": "object"
       },
+      "AppExtension": {
+        "description": "Extension is an extension blob produced by an extension parameterize step.",
+        "properties": {
+          "name": {
+            "description": "Name is the name of the extension package.",
+            "type": "string",
+            "x-order": 1
+          },
+          "value": {
+            "description": "Value is the parameter value of the extension.",
+            "items": {
+              "format": "byte",
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 3
+          },
+          "version": {
+            "description": "Version is the version of the extension package.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "name",
+          "value",
+          "version"
+        ],
+        "type": "object"
+      },
       "AppGetDefaultOrganizationResponse": {
         "description": "GetDefaultOrganizationResponse returns the backend's opinion of which organization\nto default to for a given user, if a default organization has not been configured.",
         "properties": {
@@ -2614,12 +3249,12 @@
         "description": "ImportStackRequest defines the request body for importing a Stack.",
         "properties": {
           "deployment": {
-            "description": "The opaque Pulumi deployment. This is conceptually of type `Deployment`, but we use `json.Message` to\npermit round-tripping of stack contents when an older client is talking to a newer server.  If we unmarshaled\nthe contents, and then remarshaled them, we could end up losing important information.",
+            "description": "The opaque Pulumi deployment payload. Treated as a raw JSON value so the contents are preserved verbatim across client and server versions.",
             "type": "object",
             "x-order": 3
           },
           "features": {
-            "description": "Features contains an optional list of features used by this deployment. The CLI will error when reading a\nDeployment that uses a feature that is not supported by that version of the CLI. This is only looked at\nwhen `Version` is 4 or greater.",
+            "description": "An optional list of features used by this deployment. The CLI will error when reading a deployment that uses a feature that is not supported by that version of the CLI. Only honored when `version` is 4 or greater.",
             "items": {
               "type": "string"
             },
@@ -2627,7 +3262,7 @@
             "x-order": 2
           },
           "version": {
-            "description": "Version indicates the schema of the encoded deployment.",
+            "description": "The schema version of the encoded deployment.",
             "format": "int64",
             "type": "integer",
             "x-order": 1
@@ -2646,6 +3281,20 @@
         },
         "required": [
           "updateId"
+        ],
+        "type": "object"
+      },
+      "AppInsightsAccountReference": {
+        "description": "InsightsAccountReference identifies an Insights account for policy group membership.",
+        "properties": {
+          "name": {
+            "description": "The name of the Insights account.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "name"
         ],
         "type": "object"
       },
@@ -2677,6 +3326,16 @@
             "format": "int64",
             "type": "integer",
             "x-order": 9
+          },
+          "extension": {
+            "$ref": "#/components/schemas/AppExtension",
+            "description": "Extension is an extension blob associated with this journal entry, if any.",
+            "x-order": 18
+          },
+          "extensionRef": {
+            "description": "ExtensionRef references an extension associated with this journal entry, if any.",
+            "type": "string",
+            "x-order": 17
           },
           "isRefresh": {
             "description": "If true, this journal entry is part of a refresh operation.",
@@ -2763,6 +3422,14 @@
             "format": "int64",
             "type": "integer",
             "x-order": 3
+          },
+          "snippets": {
+            "description": "Snippets are the source snippets associated with this journal entry.",
+            "items": {
+              "$ref": "#/components/schemas/AppSnippetV1"
+            },
+            "type": "array",
+            "x-order": 16
           },
           "state": {
             "$ref": "#/components/schemas/AppResourceV3",
@@ -2937,27 +3604,42 @@
               "refresh",
               "rename",
               "destroy",
-              "import"
+              "import",
+              "Pupdate",
+              "Prefresh",
+              "Pdestroy",
+              "Pimport",
+              "Prename"
             ],
             "type": "string",
             "x-order": 1,
             "x-pulumi-model-property": {
               "enumComments": "UpdateKind is an enum for the type of update performed.\nShould generally mirror backend.UpdateKind, but we clone it in this package to add\nflexibility in case there is a breaking change in the backend-type.",
               "enumFieldComments": [
-                "UpdateUpdate is the prototypical Pulumi program update.",
-                "PreviewUpdate is a preview of an update, without impacting resources.",
-                "RefreshUpdate is an update that came from a refresh operation.",
-                "RenameUpdate is an update that changes the stack name or project name of a Pulumi program.\nNOTE: Do not remove this type - it is used by Pulumi Cloud code.",
-                "DestroyUpdate is an update which removes all resources.",
-                "StackImportUpdate is an update that entails importing a raw checkpoint file."
+                "A Pulumi program update.",
+                "A preview of an update, without impacting resources.",
+                "A refresh operation.",
+                "A rename of the stack or project name.\nNOTE: Do not remove this type - it is used by Pulumi Cloud code.",
+                "An update which removes all resources.",
+                "An update that entails importing a raw checkpoint file.",
+                "A preview of an update operation.",
+                "A preview of a refresh operation.",
+                "A preview of a destroy operation.",
+                "A preview of an import operation.",
+                "A preview of a rename operation."
               ],
               "enumFieldNames": [
-                "UpdateUpdate",
+                "Update",
+                "Preview",
+                "Refresh",
+                "Rename",
+                "Destroy",
+                "Import",
                 "PreviewUpdate",
-                "RefreshUpdate",
-                "RenameUpdate",
-                "DestroyUpdate",
-                "StackImportUpdate"
+                "PreviewRefresh",
+                "PreviewDestroy",
+                "PreviewImport",
+                "PreviewRename"
               ],
               "enumTypeName": "AppUpdateKind"
             }
@@ -3009,6 +3691,65 @@
         "required": [
           "resource",
           "type"
+        ],
+        "type": "object"
+      },
+      "AppPackageDescriptorV1": {
+        "description": "PackageDescriptorV1 is the serialized form of a package descriptor for a snippet.",
+        "properties": {
+          "downloadURL": {
+            "description": "DownloadURL is the optional URL to use when downloading the provider plugin binary.",
+            "type": "string",
+            "x-order": 3
+          },
+          "name": {
+            "description": "Name is the simple name of the plugin.",
+            "type": "string",
+            "x-order": 1
+          },
+          "parameterization": {
+            "$ref": "#/components/schemas/AppParameterizationDescriptorV1",
+            "description": "Parameterization is the optional parameterization of the package.",
+            "x-order": 4
+          },
+          "version": {
+            "description": "Version is the optional version of the plugin.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "AppParameterizationDescriptorV1": {
+        "description": "ParameterizationDescriptorV1 is the serialized form of a parameterization for a packaged plugin.",
+        "properties": {
+          "name": {
+            "description": "Name is the name of the parameterized package.",
+            "type": "string",
+            "x-order": 1
+          },
+          "value": {
+            "description": "Value is the parameter value of the package.",
+            "items": {
+              "format": "byte",
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 3
+          },
+          "version": {
+            "description": "Version is the version of the parameterized package.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "name",
+          "value",
+          "version"
         ],
         "type": "object"
       },
@@ -3576,6 +4317,14 @@
             "type": "string",
             "x-order": 2
           },
+          "environments": {
+            "description": "References to ESC environments to use for this policy pack.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 6
+          },
           "name": {
             "description": "The name",
             "type": "string",
@@ -3972,6 +4721,14 @@
             "type": "string",
             "x-order": 4
           },
+          "environments": {
+            "description": "References to ESC environments whose resolved values the CLI should inject into the policy pack process.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 7
+          },
           "name": {
             "description": "The name (unique and URL-safe) of the required Policy Pack.",
             "type": "string",
@@ -4016,6 +4773,12 @@
             "format": "double",
             "type": "number",
             "x-order": 3
+          },
+          "read": {
+            "description": "Timeout in seconds for resource read operations.",
+            "format": "double",
+            "type": "number",
+            "x-order": 4
           },
           "update": {
             "description": "Timeout in seconds for resource update operations.",
@@ -4144,6 +4907,11 @@
             },
             "type": "array",
             "x-order": 12
+          },
+          "extensionRef": {
+            "description": "ExtensionRef references the extension that produced this resource, if any.",
+            "type": "string",
+            "x-order": 35
           },
           "external": {
             "description": "External is set to true when the lifecycle of this resource is not managed by Pulumi.",
@@ -4279,6 +5047,11 @@
             "type": "boolean",
             "x-order": 21
           },
+          "snippetID": {
+            "description": "SnippetID references the snippet that produced this resource, if any.",
+            "type": "string",
+            "x-order": 36
+          },
           "sourcePosition": {
             "description": "SourcePosition tracks the source location of this resource's registration",
             "type": "string",
@@ -4379,11 +5152,57 @@
         },
         "type": "object"
       },
+      "AppSnippetV1": {
+        "description": "SnippetV1 is the serialized form of a PCL snippet stored alongside a snapshot. Snippets are evaluated by the\nengine on every update to produce additional resource registrations.",
+        "properties": {
+          "code": {
+            "description": "Code is the PCL source for the body of the resource.",
+            "type": "string",
+            "x-order": 4
+          },
+          "descriptor": {
+            "$ref": "#/components/schemas/AppPackageDescriptorV1",
+            "description": "Descriptor identifies the package that owns the resource type.",
+            "x-order": 5
+          },
+          "name": {
+            "description": "Name is the logical name of the resource this snippet registers.",
+            "type": "string",
+            "x-order": 2
+          },
+          "references": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "References declares external resources that the snippet's Code may refer to by HCL identifier. The map\nkey is the identifier used inside Code; the value is the URN of the target resource.",
+            "type": "object",
+            "x-order": 6
+          },
+          "type": {
+            "description": "Type is the type token of the resource this snippet registers.",
+            "type": "string",
+            "x-order": 3
+          },
+          "uuid": {
+            "description": "UUID is the stable identity of this snippet within the snapshot.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "code",
+          "descriptor",
+          "name",
+          "type",
+          "uuid"
+        ],
+        "type": "object"
+      },
       "AppStack": {
         "description": "Stack describes a Stack running on a Pulumi Cloud.",
         "properties": {
           "activeUpdate": {
-            "description": "The active update",
+            "description": "UUID of the most recent update on this stack, either completed or in-progress.",
             "type": "string",
             "x-order": 6
           },
@@ -4394,11 +5213,11 @@
           },
           "currentOperation": {
             "$ref": "#/components/schemas/AppOperationStatus",
-            "description": "CurrentOperation provides information about a stack operation in-progress, as applicable.",
+            "description": "Information about a live operation currently running for the stack, its kind, the author who initiated it, and its start time. Null when no operation is in flight.",
             "x-order": 5
           },
           "id": {
-            "description": "ID is the logical ID of the stack. For maintainers of the Pulumi service:\nID corresponds to the Program ID, not the Stack ID inside the Pulumi service.",
+            "description": "The logical identifier of the stack.",
             "type": "string",
             "x-order": 1
           },
@@ -4446,12 +5265,14 @@
         "description": "StackConfig describes the configuration of a stack from Pulumi Cloud.",
         "properties": {
           "encryptedKey": {
-            "description": "EncryptedKey is the KMS-encrypted ciphertext for the data key used for secrets encryption.\nOnly used for cloud-based secrets providers.",
+            "deprecated": true,
+            "description": "Deprecated: this field is no longer used by the service. Stacks that use a service-backed configuration store all config (including secrets) in ESC, which uses its own encryption. New callers should omit this field.",
             "type": "string",
             "x-order": 3
           },
           "encryptionSalt": {
-            "description": "EncryptionSalt is this stack's base64 encoded encryption salt. Only used for\npassphrase-based secrets providers.",
+            "deprecated": true,
+            "description": "Deprecated: this field is no longer used by the service. Stacks that use a service-backed configuration store all config (including secrets) in ESC, which uses its own encryption. New callers should omit this field.",
             "type": "string",
             "x-order": 4
           },
@@ -4461,7 +5282,8 @@
             "x-order": 1
           },
           "secretsProvider": {
-            "description": "SecretsProvider is this stack's secrets provider.",
+            "deprecated": true,
+            "description": "Deprecated: this field is no longer used by the service. Stacks that use a service-backed configuration store all config (including secrets) in ESC, which uses its own encryption. New callers should omit this field.",
             "type": "string",
             "x-order": 2
           }
@@ -4520,7 +5342,7 @@
         "description": "StackSummary describes the state of a stack, without including its specific resources, etc.",
         "properties": {
           "id": {
-            "description": "ID is the logical ID of the stack. For maintainers of the Pulumi service:\nID corresponds to the Program ID, not the Stack ID inside the Pulumi service.",
+            "description": "The logical identifier of the stack.",
             "type": "string",
             "x-order": 1
           },
@@ -4658,7 +5480,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/AppPropertyDiff"
             },
-            "description": "The diff for this step as a list of property paths and difference types.\nNOTE: We don't want to omitempty this field because we want to distinguish between\na nil value and an empty map. See https://github.com/pulumi/pulumi/pull/15213 for details.",
+            "description": "The diff for this step as a map of property paths to difference types. An empty map indicates no detailed property-level diff is available; if this field is omitted or null, the diff was not computed.",
             "type": "object",
             "x-order": 8
           },
@@ -4671,7 +5493,7 @@
             "x-order": 7
           },
           "keys": {
-            "description": "Keys causing a replacement (only applicable for \"create\" and \"replace\" Ops).",
+            "description": "Keys causing a replacement (only applicable for `create` and `replace` Ops).",
             "items": {
               "type": "string"
             },
@@ -4793,13 +5615,18 @@
             "type": "boolean",
             "x-order": 4
           },
+          "external": {
+            "description": "True if the resource is external to Pulumi (its lifecycle is managed outside of Pulumi).",
+            "type": "boolean",
+            "x-order": 14
+          },
           "hideDiffs": {
             "description": "HideDiffs is the set of property paths where diffs are not displayed.",
             "items": {
               "type": "string"
             },
             "type": "array",
-            "x-order": 14
+            "x-order": 15
           },
           "id": {
             "description": "ID is the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).",
@@ -4884,7 +5711,7 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "PolicyPacks run during update. Maps PolicyPackName -> version.\nNote: When this field was initially added, we forgot to add the JSON tag\nand are now locked into to using PascalCase for this field to maintain backwards\ncompatibility. For older clients this will map to the version, while for newer ones\nit will be the version tag prepended with \"v\".",
+            "description": "Policy Packs run during the update, as a map from policy pack name to version. For newer clients, the value is the version tag prefixed with `v`; for older clients it is the raw version.",
             "type": "object",
             "x-order": 4
           },
@@ -4912,6 +5739,25 @@
             "description": "ResourceChanges contains the count for resource change by type.",
             "type": "object",
             "x-order": 3
+          },
+          "result": {
+            "description": "Result is the high-level outcome of the operation.",
+            "enum": [
+              "succeeded",
+              "failed",
+              "canceled"
+            ],
+            "type": "string",
+            "x-order": 6,
+            "x-pulumi-model-property": {
+              "enumComments": "OperationResult is the high-level outcome of an operation.",
+              "enumFieldComments": [
+                "OperationResultSucceeded indicates the operation completed without error.",
+                "OperationResultFailed indicates the operation returned an error.",
+                "OperationResultCanceled indicates the operation was canceled by the user."
+              ],
+              "enumTypeName": "AppOperationResult"
+            }
           }
         },
         "required": [
@@ -4919,7 +5765,8 @@
           "durationSeconds",
           "isPreview",
           "maybeCorrupt",
-          "resourceChanges"
+          "resourceChanges",
+          "result"
         ],
         "type": "object"
       },
@@ -4927,12 +5774,12 @@
         "description": "UntypedDeployment contains an inner, untyped deployment structure.",
         "properties": {
           "deployment": {
-            "description": "The opaque Pulumi deployment. This is conceptually of type `Deployment`, but we use `json.Message` to\npermit round-tripping of stack contents when an older client is talking to a newer server.  If we unmarshaled\nthe contents, and then remarshaled them, we could end up losing important information.",
+            "description": "The opaque Pulumi deployment payload. Treated as a raw JSON value so the contents are preserved verbatim across client and server versions.",
             "type": "object",
             "x-order": 3
           },
           "features": {
-            "description": "Features contains an optional list of features used by this deployment. The CLI will error when reading a\nDeployment that uses a feature that is not supported by that version of the CLI. This is only looked at\nwhen `Version` is 4 or greater.",
+            "description": "An optional list of features used by this deployment. The CLI will error when reading a deployment that uses a feature that is not supported by that version of the CLI. Only honored when `version` is 4 or greater.",
             "items": {
               "type": "string"
             },
@@ -4940,7 +5787,7 @@
             "x-order": 2
           },
           "version": {
-            "description": "Version indicates the schema of the encoded deployment.",
+            "description": "The schema version of the encoded deployment.",
             "format": "int64",
             "type": "integer",
             "x-order": 1
@@ -5031,27 +5878,42 @@
               "refresh",
               "rename",
               "destroy",
-              "import"
+              "import",
+              "Pupdate",
+              "Prefresh",
+              "Pdestroy",
+              "Pimport",
+              "Prename"
             ],
             "type": "string",
             "x-order": 1,
             "x-pulumi-model-property": {
               "enumComments": "UpdateKind is an enum for the type of update performed.\nShould generally mirror backend.UpdateKind, but we clone it in this package to add\nflexibility in case there is a breaking change in the backend-type.",
               "enumFieldComments": [
-                "UpdateUpdate is the prototypical Pulumi program update.",
-                "PreviewUpdate is a preview of an update, without impacting resources.",
-                "RefreshUpdate is an update that came from a refresh operation.",
-                "RenameUpdate is an update that changes the stack name or project name of a Pulumi program.\nNOTE: Do not remove this type - it is used by Pulumi Cloud code.",
-                "DestroyUpdate is an update which removes all resources.",
-                "StackImportUpdate is an update that entails importing a raw checkpoint file."
+                "A Pulumi program update.",
+                "A preview of an update, without impacting resources.",
+                "A refresh operation.",
+                "A rename of the stack or project name.\nNOTE: Do not remove this type - it is used by Pulumi Cloud code.",
+                "An update which removes all resources.",
+                "An update that entails importing a raw checkpoint file.",
+                "A preview of an update operation.",
+                "A preview of a refresh operation.",
+                "A preview of a destroy operation.",
+                "A preview of an import operation.",
+                "A preview of a rename operation."
               ],
               "enumFieldNames": [
-                "UpdateUpdate",
+                "Update",
+                "Preview",
+                "Refresh",
+                "Rename",
+                "Destroy",
+                "Import",
                 "PreviewUpdate",
-                "RefreshUpdate",
-                "RenameUpdate",
-                "DestroyUpdate",
-                "StackImportUpdate"
+                "PreviewRefresh",
+                "PreviewDestroy",
+                "PreviewImport",
+                "PreviewRename"
               ],
               "enumTypeName": "AppUpdateKind"
             }
@@ -5089,16 +5951,16 @@
             "x-pulumi-model-property": {
               "enumComments": "UpdateResult is an enum for the result of the update.\nShould generally mirror backend.UpdateResult, but we clone it in this package to add\nflexibility in case there is a breaking change in the backend-type.",
               "enumFieldComments": [
-                "NotStartedResult is for updates that have not started.",
-                "InProgressResult is for updates that have not yet completed.",
-                "SucceededResult is for updates that completed successfully.",
-                "FailedResult is for updates that have failed."
+                "The update has not started.",
+                "The update has not yet completed.",
+                "The update completed successfully.",
+                "The update has failed."
               ],
               "enumFieldNames": [
-                "NotStartedResult",
-                "InProgressResult",
-                "SucceededResult",
-                "FailedResult"
+                "NotStarted",
+                "InProgress",
+                "Succeeded",
+                "Failed"
               ],
               "enumTypeName": "AppUpdateResult"
             }
@@ -5220,6 +6082,11 @@
       "AppUpdatePolicyGroupRequest": {
         "description": "UpdatePolicyGroupRequest modifies a Policy Group.",
         "properties": {
+          "addInsightsAccount": {
+            "$ref": "#/components/schemas/AppInsightsAccountReference",
+            "description": "An Insights account to add to the policy group.",
+            "x-order": 6
+          },
           "addPolicyPack": {
             "$ref": "#/components/schemas/AppPolicyPackMetadata",
             "description": "A policy pack to enable for the policy group.",
@@ -5230,10 +6097,31 @@
             "description": "A stack to add to the policy group.",
             "x-order": 2
           },
+          "insightsAccounts": {
+            "description": "When non-nil, replaces the full list of Insights accounts in the group.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 10
+          },
           "newName": {
             "description": "The new name to assign to the policy group.",
             "type": "string",
             "x-order": 1
+          },
+          "policyPacks": {
+            "description": "When non-nil, replaces the full list of Policy Packs applied to the group.",
+            "items": {
+              "$ref": "#/components/schemas/AppPolicyPackMetadata"
+            },
+            "type": "array",
+            "x-order": 9
+          },
+          "removeInsightsAccount": {
+            "$ref": "#/components/schemas/AppInsightsAccountReference",
+            "description": "An Insights account to remove from the policy group.",
+            "x-order": 7
           },
           "removePolicyPack": {
             "$ref": "#/components/schemas/AppPolicyPackMetadata",
@@ -5244,6 +6132,14 @@
             "$ref": "#/components/schemas/AppPulumiStackReference",
             "description": "A stack to remove from the policy group.",
             "x-order": 3
+          },
+          "stacks": {
+            "description": "When non-nil, replaces the full list of stacks in the group.",
+            "items": {
+              "$ref": "#/components/schemas/AppPulumiStackReference"
+            },
+            "type": "array",
+            "x-order": 8
           }
         },
         "type": "object"
@@ -5389,44 +6285,6 @@
         "required": [
           "events",
           "status"
-        ],
-        "type": "object"
-      },
-      "AppendMessageToConversationRequest": {
-        "description": "Request body for appending a message to a Copilot conversation.",
-        "properties": {
-          "message": {
-            "description": "The message text to append to the conversation.",
-            "type": "string",
-            "x-order": 2
-          },
-          "message_schema_version": {
-            "description": "Schema version of the message format, for forward/backward compatibility.",
-            "type": "string",
-            "x-order": 3
-          },
-          "model": {
-            "description": "The AI model to use for generating the response (e.g. 'gpt-4', 'claude-3').",
-            "type": "string",
-            "x-order": 1
-          },
-          "role": {
-            "description": "The role of the message sender (e.g. 'user', 'assistant', 'system').",
-            "type": "string",
-            "x-order": 5
-          },
-          "skills": {
-            "description": "Comma-separated list of skill identifiers to enable for this message.",
-            "type": "string",
-            "x-order": 4
-          }
-        },
-        "required": [
-          "message",
-          "message_schema_version",
-          "model",
-          "role",
-          "skills"
         ],
         "type": "object"
       },
@@ -6761,6 +7619,9 @@
                 "x-order": 1
               }
             },
+            "required": [
+              "user"
+            ],
             "type": "object"
           }
         ]
@@ -6846,7 +7707,7 @@
             "x-order": 3
           },
           "reqOrgAdmin": {
-            "description": "Whether or not triggering the audit log event required the ADMIN role in an org\nor if it required the ADMIN role in a stack. Marking omitempty to avoid increasing\nJSON payload size by too much.",
+            "description": "Whether the action that triggered this event required the organization ADMIN role.",
             "type": "boolean",
             "x-order": 8
           },
@@ -7153,6 +8014,11 @@
       "AzureDevOpsIntegrationDetails": {
         "description": "AzureDevOpsIntegrationDetails describes a single Azure DevOps integration installation.",
         "properties": {
+          "disableCodeAccessForReviews": {
+            "description": "Whether code access for AI reviews is disabled for this integration",
+            "type": "boolean",
+            "x-order": 8
+          },
           "disableDetailedDiff": {
             "description": "Whether detailed property-level diffs are disabled for PR comments",
             "type": "boolean",
@@ -7330,6 +8196,11 @@
       "AzureSetupRequest": {
         "description": "Request to setup Azure infrastructure and ESC environments",
         "properties": {
+          "appObjectId": {
+            "description": "Object ID of the app registration created by a prior AzureSetup call. When set, the app registration is resolved by ID instead of searched by display name, so batched setup calls cannot land on different app registrations.",
+            "type": "string",
+            "x-order": 4
+          },
           "armSessionId": {
             "description": "ARM (Azure Resource Manager) OAuth session ID",
             "type": "string",
@@ -7347,6 +8218,11 @@
             "description": "Microsoft Graph OAuth session ID",
             "type": "string",
             "x-order": 2
+          },
+          "servicePrincipalId": {
+            "description": "Object ID of the service principal created by a prior AzureSetup call. When set, the service principal lookup is skipped and roles are assigned to this principal.",
+            "type": "string",
+            "x-order": 5
           }
         },
         "required": [
@@ -7384,6 +8260,14 @@
             "description": "The org identifier",
             "type": "string",
             "x-order": 1
+          },
+          "Tags": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Optional key-value tags associated with the usage record",
+            "type": "object",
+            "x-order": 6
           },
           "Timestamp": {
             "description": "The usage timestamp",
@@ -7455,6 +8339,407 @@
         },
         "type": "object"
       },
+      "BatchCreateOrganizationInviteRequest": {
+        "description": "Request body for batch create organization invite.",
+        "properties": {
+          "invites": {
+            "description": "List of invites",
+            "items": {
+              "$ref": "#/components/schemas/CreateOrganizationInviteRequest"
+            },
+            "type": "array",
+            "x-order": 1
+          },
+          "token": {
+            "description": "Turnstile token",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "invites"
+        ],
+        "type": "object"
+      },
+      "BatchCreateOrganizationInviteResponse": {
+        "description": "Response body for batch create organization invite.",
+        "properties": {
+          "failedInvites": {
+            "description": "List of failed invites",
+            "items": {
+              "$ref": "#/components/schemas/CreateOrganizationInviteRequest"
+            },
+            "type": "array",
+            "x-order": 2
+          },
+          "sentInvites": {
+            "description": "List of sent invites",
+            "items": {
+              "$ref": "#/components/schemas/CreateOrganizationInviteResponse"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "failedInvites",
+          "sentInvites"
+        ],
+        "type": "object"
+      },
+      "BitBucketAccessStatusResponse": {
+        "description": "Information about a user's BitBucket access status, including whether they have a valid OAuth token and which workspaces are available.",
+        "properties": {
+          "availableWorkspaces": {
+            "description": "List of BitBucket workspaces available to the user for integration.",
+            "items": {
+              "$ref": "#/components/schemas/BitBucketWorkspace"
+            },
+            "type": "array",
+            "x-order": 2
+          },
+          "hasUserToken": {
+            "description": "Whether the current user has a valid BitBucket OAuth token.",
+            "type": "boolean",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "hasUserToken"
+        ],
+        "type": "object"
+      },
+      "BitBucketIntegrationDetails": {
+        "description": "Detailed information about a BitBucket VCS integration, including its configuration, authentication method, and validity status.",
+        "properties": {
+          "authType": {
+            "description": "The authentication type used: 'workspace_token', 'user_token', or 'pat'.",
+            "type": "string",
+            "x-order": 8
+          },
+          "authUser": {
+            "$ref": "#/components/schemas/User",
+            "description": "The user whose BitBucket OAuth token is being used for authentication, if user-based auth is configured.",
+            "x-order": 9
+          },
+          "avatarUrl": {
+            "description": "URL of the BitBucket workspace avatar image.",
+            "type": "string",
+            "x-order": 5
+          },
+          "disableDetailedDiff": {
+            "description": "Whether detailed property-level diffs are disabled for PR comments.",
+            "type": "boolean",
+            "x-order": 12
+          },
+          "disableNeoSummaries": {
+            "description": "Whether Neo AI summaries are disabled for this integration.",
+            "type": "boolean",
+            "x-order": 11
+          },
+          "disablePRComments": {
+            "description": "Whether PR comments are disabled for this integration.",
+            "type": "boolean",
+            "x-order": 10
+          },
+          "id": {
+            "description": "Unique identifier for this BitBucket integration.",
+            "type": "string",
+            "x-order": 1
+          },
+          "installed": {
+            "description": "Whether this integration is fully installed and operational.",
+            "type": "boolean",
+            "x-order": 6
+          },
+          "valid": {
+            "description": "Whether the integration's credentials are currently valid.",
+            "type": "boolean",
+            "x-order": 7
+          },
+          "workspaceName": {
+            "description": "Display name of the BitBucket workspace.",
+            "type": "string",
+            "x-order": 4
+          },
+          "workspaceSlug": {
+            "description": "The slug (URL-friendly name) of the linked BitBucket workspace.",
+            "type": "string",
+            "x-order": 3
+          },
+          "workspaceUuid": {
+            "description": "The UUID of the linked BitBucket workspace.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "disableDetailedDiff",
+          "disableNeoSummaries",
+          "disablePRComments",
+          "id",
+          "installed",
+          "valid",
+          "workspaceSlug",
+          "workspaceUuid"
+        ],
+        "type": "object"
+      },
+      "BitBucketSettingsRequest": {
+        "description": "Request body for updating BitBucket integration settings such as PR comment preferences and AI summary options.",
+        "properties": {
+          "disableDetailedDiff": {
+            "description": "If true, disable detailed property-level diffs in PR comments.",
+            "type": "boolean",
+            "x-order": 3
+          },
+          "disableNeoSummaries": {
+            "description": "If true, disable Neo AI-generated deployment summaries in PR comments.",
+            "type": "boolean",
+            "x-order": 2
+          },
+          "disablePRComments": {
+            "description": "If true, disable automatic PR comments on deployments.",
+            "type": "boolean",
+            "x-order": 1
+          }
+        },
+        "type": "object"
+      },
+      "BitBucketSetupRequest": {
+        "description": "Request body for creating a new BitBucket VCS integration. Specifies the workspace to integrate and the authentication method.",
+        "properties": {
+          "useUserAuth": {
+            "description": "If true, use the current user's BitBucket OAuth token for authentication instead of a workspace access token.",
+            "type": "boolean",
+            "x-order": 3
+          },
+          "workspaceAccessToken": {
+            "description": "Optional workspace access token or personal access token (PAT) for authenticating with the BitBucket API. Required if useUserAuth is false.",
+            "type": "string",
+            "x-order": 4
+          },
+          "workspaceSlug": {
+            "description": "The slug (URL-friendly name) of the BitBucket workspace.",
+            "type": "string",
+            "x-order": 2
+          },
+          "workspaceUuid": {
+            "description": "The UUID of the BitBucket workspace to integrate.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "workspaceSlug",
+          "workspaceUuid"
+        ],
+        "type": "object"
+      },
+      "BitBucketWorkspace": {
+        "description": "Represents a BitBucket workspace with its identifying information.",
+        "properties": {
+          "avatarUrl": {
+            "description": "URL of the workspace's avatar image.",
+            "type": "string",
+            "x-order": 4
+          },
+          "name": {
+            "description": "The display name of the workspace.",
+            "type": "string",
+            "x-order": 2
+          },
+          "slug": {
+            "description": "The URL-friendly slug of the workspace.",
+            "type": "string",
+            "x-order": 3
+          },
+          "uuid": {
+            "description": "The unique UUID of the BitBucket workspace.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "uuid"
+        ],
+        "type": "object"
+      },
+      "BulkCreateInsightsAccountFailure": {
+        "description": "Details about a single account that failed to be created during a bulk operation.",
+        "properties": {
+          "error": {
+            "description": "A human-readable error message describing why the account creation failed.",
+            "type": "string",
+            "x-order": 2
+          },
+          "name": {
+            "description": "The name of the account that failed to be created.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "error",
+          "name"
+        ],
+        "type": "object"
+      },
+      "BulkCreateInsightsAccountItem": {
+        "description": "Definition of a single Insights account to create as part of a bulk operation.",
+        "properties": {
+          "agentPoolID": {
+            "description": "The ID of the agent pool to run account discovery workflows.\nIf not specified, discovery will use the default agent pool.",
+            "type": "string",
+            "x-order": 5
+          },
+          "environment": {
+            "description": "Reference to an ESC environment containing provider credentials,\nin the format 'project/environment' with an optional @version suffix.",
+            "type": "string",
+            "x-order": 3
+          },
+          "name": {
+            "description": "The name of the account to create. Must be unique within the organization.",
+            "type": "string",
+            "x-order": 1
+          },
+          "provider": {
+            "description": "The cloud provider for the account (e.g., aws, gcp, azure-native).",
+            "enum": [
+              "aws",
+              "gcp",
+              "azure-native",
+              "oci",
+              "kubernetes"
+            ],
+            "type": "string",
+            "x-order": 2,
+            "x-pulumi-model-property": {
+              "enumComments": "InsightsAccountProvider is an enum defining the cloud provider for an Insights account.",
+              "enumFieldComments": [
+                "Amazon Web Services provider.",
+                "Google Cloud Platform provider.",
+                "Azure Native provider.",
+                "Oracle Cloud Infrastructure provider.",
+                "Kubernetes provider."
+              ],
+              "enumFieldNames": [
+                "Aws",
+                "Gcp",
+                "AzureNative",
+                "Oci",
+                "Kubernetes"
+              ],
+              "enumTypeName": "InsightsAccountProvider"
+            }
+          },
+          "providerConfig": {
+            "description": "Provider-specific configuration for the account.",
+            "type": "object",
+            "x-order": 6
+          },
+          "scanSchedule": {
+            "description": "Schedule for automated discovery scans (e.g., 'none', 'daily').",
+            "enum": [
+              "none",
+              "12h",
+              "daily"
+            ],
+            "type": "string",
+            "x-order": 4,
+            "x-pulumi-model-property": {
+              "enumComments": "ScanSchedule represents the schedule for automated scans.",
+              "enumFieldComments": [
+                "No automated scanning is configured.",
+                "Scans run automatically every 12 hours.",
+                "Scans run automatically on a daily schedule."
+              ],
+              "enumFieldNames": [
+                "None",
+                "TwelveHours",
+                "Daily"
+              ],
+              "enumTypeName": "ScanSchedule"
+            }
+          }
+        },
+        "required": [
+          "environment",
+          "name",
+          "provider"
+        ],
+        "type": "object"
+      },
+      "BulkCreateInsightsAccountsRequest": {
+        "description": "Request body for creating multiple Insights accounts in a single operation. Each account is created independently; failures for individual accounts do not prevent other accounts from being created.",
+        "properties": {
+          "accounts": {
+            "description": "The list of accounts to create. Each item defines a single Insights account with its provider, ESC environment reference, and optional configuration. Maximum 100 accounts per request.",
+            "items": {
+              "$ref": "#/components/schemas/BulkCreateInsightsAccountItem"
+            },
+            "type": "array",
+            "x-order": 1
+          },
+          "skipAutoEnablePolicyPacks": {
+            "description": "When true, skips automatic enablement of policy packs based on subscription tier. By default, SKU-appropriate policy packs are added to the default accounts policy group when accounts are created.",
+            "type": "boolean",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "accounts"
+        ],
+        "type": "object"
+      },
+      "BulkCreateInsightsAccountsResponse": {
+        "description": "Response from a bulk Insights account creation operation. Contains both successfully created accounts and details about any failures.",
+        "properties": {
+          "accounts": {
+            "description": "The list of accounts that were successfully created.",
+            "items": {
+              "$ref": "#/components/schemas/InsightsAccount"
+            },
+            "type": "array",
+            "x-order": 1
+          },
+          "failures": {
+            "description": "The list of accounts that failed to be created, with error details.",
+            "items": {
+              "$ref": "#/components/schemas/BulkCreateInsightsAccountFailure"
+            },
+            "type": "array",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "accounts",
+          "failures"
+        ],
+        "type": "object"
+      },
+      "CLIIntegrationRef": {
+        "description": "Reference to a CLI integration instance, addressed by (catalogId, name) — the same scheme used by the connect/disconnect endpoints. Structured as an object rather than a bare 'catalogId/name' string so additional fields (e.g. scope) can be added later without a wire break, and so the encoding is unambiguous regardless of characters that may appear in the instance name.",
+        "properties": {
+          "catalogId": {
+            "description": "The CLI catalog entry ID (e.g. 'aws').",
+            "type": "string",
+            "x-order": 1
+          },
+          "name": {
+            "description": "The user-chosen instance name. Unique within the (org, catalogId) pair.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "catalogId",
+          "name"
+        ],
+        "type": "object"
+      },
       "CacheOptions": {
         "description": "Configuration options for deployment build caching.",
         "properties": {
@@ -7480,37 +8765,17 @@
         },
         "type": "object"
       },
-      "CacheURLRequest": {
-        "description": "Request body for cache url.",
+      "CancelAgentTaskRequest": {
+        "description": "Request body for cancelling an agent task. When force is true, the runtime session is terminated immediately and the task is reset to idle, even if it is currently running. This is the escalation path when a graceful cancel is insufficient or the task is stuck.",
         "properties": {
-          "key": {
-            "description": "The key",
-            "type": "string",
-            "x-order": 2
-          },
-          "method": {
-            "description": "S3 method of the presigned URL",
-            "type": "string",
+          "force": {
+            "description": "If true, immediately terminate the runtime session and reset the task to idle without attempting a graceful cancel. Required to be true in the current implementation.",
+            "type": "boolean",
             "x-order": 1
           }
         },
         "required": [
-          "key",
-          "method"
-        ],
-        "type": "object"
-      },
-      "CacheURLResponse": {
-        "description": "Response body for cache url.",
-        "properties": {
-          "url": {
-            "description": "The URL",
-            "type": "string",
-            "x-order": 1
-          }
-        },
-        "required": [
-          "url"
+          "force"
         ],
         "type": "object"
       },
@@ -8175,6 +9440,69 @@
           }
         ]
       },
+      "ClaimGitHubIntegrationRequest": {
+        "description": "ClaimGitHubIntegrationRequest identifies an existing, unlinked Pulumi GitHub App installation to link to an organization.",
+        "properties": {
+          "installationId": {
+            "description": "The numeric GitHub App installation ID to link, as assigned by GitHub.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "installationId"
+        ],
+        "type": "object"
+      },
+      "ClaimableGitHubIntegration": {
+        "description": "ClaimableGitHubIntegration describes an unlinked Pulumi GitHub App installation that could be linked to a Pulumi organization.",
+        "properties": {
+          "accountAvatarUrl": {
+            "description": "The avatar URL of the GitHub account the app is installed on.",
+            "type": "string",
+            "x-order": 3
+          },
+          "accountLogin": {
+            "description": "The login of the GitHub account (user or organization) the app is installed on.",
+            "type": "string",
+            "x-order": 2
+          },
+          "installationId": {
+            "description": "The numeric GitHub App installation ID, as assigned by GitHub.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 1
+          },
+          "isOrganization": {
+            "description": "Whether the GitHub account is an organization (as opposed to a personal account).",
+            "type": "boolean",
+            "x-order": 4
+          }
+        },
+        "required": [
+          "installationId",
+          "isOrganization"
+        ],
+        "type": "object"
+      },
+      "ClaimableGitHubIntegrationsResponse": {
+        "description": "ClaimableGitHubIntegrationsResponse lists unlinked Pulumi GitHub App installations the caller could link to an organization.",
+        "properties": {
+          "installations": {
+            "description": "The unlinked installations available to link.",
+            "items": {
+              "$ref": "#/components/schemas/ClaimableGitHubIntegration"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "installations"
+        ],
+        "type": "object"
+      },
       "CloneEnvironmentRequest": {
         "description": "Request body for cloning an ESC environment to a new environment.",
         "properties": {
@@ -8547,38 +9875,6 @@
           }
         ]
       },
-      "Conversation": {
-        "description": "Represents conversation.",
-        "properties": {
-          "created": {
-            "description": "The creation timestamp",
-            "type": "string",
-            "x-order": 2
-          },
-          "id": {
-            "description": "The unique identifier",
-            "type": "string",
-            "x-order": 1
-          },
-          "summary": {
-            "description": "The summary",
-            "type": "string",
-            "x-order": 4
-          },
-          "title": {
-            "description": "The title",
-            "type": "string",
-            "x-order": 3
-          }
-        },
-        "required": [
-          "created",
-          "id",
-          "summary",
-          "title"
-        ],
-        "type": "object"
-      },
       "CreateAccessTokenResponse": {
         "description": "CreateAccessTokenResponse is the shape of the response after creating a token. The ID is an opaque ID that can be used\nin future CRUD operations and the Token is the actual token value (that is presented in the authorization header).",
         "properties": {
@@ -8616,9 +9912,25 @@
               "enumTypeName": "NeoApprovalMode"
             }
           },
+          "cliIntegrations": {
+            "description": "Optional filter for CLI integrations to enable for this task. Semantics: omitted/null → enable all CLI integrations connected for the org; empty list → explicit opt-out (no CLI integrations for this task); populated list → whitelist by (catalogId, name) of the configured instances to enable. Entries with missing or unknown catalogId, missing name, or referencing a (catalogId, name) pair that is not connected for the organization are rejected with a 400 response. catalogId matching is case-insensitive.",
+            "items": {
+              "$ref": "#/components/schemas/CLIIntegrationRef"
+            },
+            "type": "array",
+            "x-order": 9
+          },
+          "enabledIntegrations": {
+            "description": "Optional list of integrations to enable for this task. Semantics: omitted/null → inherit all org-enabled integrations; empty list → explicit opt-out (no integration credentials for this task); populated list → whitelist of specific integrations by ID. Modeled as an object array rather than a bare string array so multi-instance support (instance_name, scope, etc.) can be added later without a wire break.",
+            "items": {
+              "$ref": "#/components/schemas/AgentTaskIntegrationRef"
+            },
+            "type": "array",
+            "x-order": 7
+          },
           "message": {
             "$ref": "#/components/schemas/AgentUserEventMessage",
-            "description": "The message content",
+            "description": "The message content. This is the first event in the conversation and must be a user message, so its discriminator field must be set to \"type\": \"user_message\".",
             "x-order": 1
           },
           "permissionMode": {
@@ -8642,6 +9954,61 @@
             "description": "Whether to enable plan mode for this task.",
             "type": "boolean",
             "x-order": 3
+          },
+          "role": {
+            "description": "Optional RBAC role the task assumes, identified by role id. When set, the task operates with that role's permissions in place of the creating user's own assignments. You may only assume a role that is assigned to you, directly or through a team; a role you do not hold is rejected with a 403. Omitted/null means no assumed role: the task uses the creating user's full permissions. Orthogonal to permissionMode, which controls the read-only behavior posture independently.",
+            "type": "string",
+            "x-order": 5
+          },
+          "source": {
+            "description": "The origin that triggered this task. Defaults to 'api' if omitted.",
+            "enum": [
+              "api",
+              "console",
+              "cli",
+              "slack",
+              "schedule",
+              "github",
+              "code-review"
+            ],
+            "type": "string",
+            "x-order": 8,
+            "x-pulumi-model-property": {
+              "enumComments": "Identifies the origin that triggered a Neo agent task.",
+              "enumFieldComments": [
+                "Task created via the REST API without a more specific origin.",
+                "Task created from the Pulumi Cloud web console.",
+                "Task created from the Pulumi CLI.",
+                "Task created from the Slack integration.",
+                "Task created by a scheduled automation.",
+                "Task triggered from a GitHub integration.",
+                "Task created by the code review feature. The platform hosting the reviewed change is identified by the task's vcsProvider field."
+              ],
+              "enumFieldNames": [
+                "Api",
+                "Console",
+                "Cli",
+                "Slack",
+                "Schedule",
+                "Github",
+                "CodeReview"
+              ],
+              "enumTypeName": "AgentTaskSource"
+            }
+          },
+          "toolExecutionMode": {
+            "description": "Where tools should be executed. Defaults to 'cloud' if omitted.",
+            "enum": [
+              "cloud",
+              "cli",
+              "worker"
+            ],
+            "type": "string",
+            "x-order": 6,
+            "x-pulumi-model-property": {
+              "enumComments": "Where tools are executed for an agent task.",
+              "enumTypeName": "ToolExecutionMode"
+            }
           }
         },
         "type": "object"
@@ -8692,22 +10059,46 @@
         ],
         "type": "object"
       },
-      "CreateConversationRequest": {
-        "description": "Request body for creating a conversation.",
+      "CreateCustomVCSIntegrationRequest": {
+        "description": "Request to create a new custom VCS integration for an organization. Custom VCS integrations allow connecting self-hosted or third-party version control systems (e.g. Gitea, Forgejo, Bitbucket Server) to Pulumi Deployments via ESC-managed credentials and inbound webhooks.",
         "properties": {
-          "conversation_id": {
-            "description": "Unique identifier for the conversation, provided by the client.",
+          "baseUrl": {
+            "description": "URL prefix for repositories covered by this integration (e.g. 'https://gitea.example.com/myorg'). Used to match repositories to integrations.",
+            "type": "string",
+            "x-order": 2
+          },
+          "environment": {
+            "description": "ESC environment reference in 'project/envName' format containing VCS credentials (e.g. SSH keys, access tokens) used for repository operations",
+            "type": "string",
+            "x-order": 3
+          },
+          "name": {
+            "description": "Human-readable name for the integration, unique within the organization (e.g. 'Gitea Production')",
             "type": "string",
             "x-order": 1
           },
-          "origin": {
-            "description": "The origin",
+          "vcsType": {
+            "description": "Version control system type. Defaults to 'git' if not specified.",
+            "enum": [
+              "git",
+              "hg"
+            ],
             "type": "string",
-            "x-order": 2
+            "x-order": 4,
+            "x-pulumi-model-property": {
+              "enumComments": "VCSType describes the version control system type for a custom VCS integration.",
+              "enumFieldComments": [
+                "Git version control system",
+                "Mercurial version control system"
+              ],
+              "enumTypeName": "VCSType"
+            }
           }
         },
         "required": [
-          "conversation_id"
+          "baseUrl",
+          "environment",
+          "name"
         ],
         "type": "object"
       },
@@ -8720,7 +10111,7 @@
             "description": "CreateDeploymentRequest defines the request payload that is expected when creating a new deployment.",
             "properties": {
               "inheritSettings": {
-                "description": "InheritSettings indicates whether this deployment should inherit the stack's deployment settings.",
+                "description": "Whether this deployment should inherit the stack's deployment settings. Defaults to true.",
                 "type": "boolean",
                 "x-order": 2
               },
@@ -8758,17 +10149,17 @@
         "description": "CreateDeploymentResponse defines the response given when a new Deployment is created.",
         "properties": {
           "consoleUrl": {
-            "description": "ConsoleURL is the Console URL for the deployment.",
+            "description": "The Pulumi Console URL for the deployment.",
             "type": "string",
             "x-order": 2
           },
           "id": {
-            "description": "ID represents the generated Deployment ID.",
+            "description": "The generated deployment identifier.",
             "type": "string",
             "x-order": 1
           },
           "version": {
-            "description": "Version is the numerical sequential version for the deployment.",
+            "description": "The numerical sequential version for the deployment.",
             "format": "int64",
             "type": "integer",
             "x-order": 3
@@ -8863,12 +10254,12 @@
         "description": "Request body for create environment.",
         "properties": {
           "name": {
-            "description": "The name",
+            "description": "The name of the environment.",
             "type": "string",
             "x-order": 2
           },
           "project": {
-            "description": "The project",
+            "description": "The project name for the environment.",
             "type": "string",
             "x-order": 1
           }
@@ -9028,6 +10419,7 @@
             "description": "Schedule for automated discovery scans (e.g., 'none', 'daily').",
             "enum": [
               "none",
+              "12h",
               "daily"
             ],
             "type": "string",
@@ -9036,7 +10428,13 @@
               "enumComments": "ScanSchedule represents the schedule for automated scans.",
               "enumFieldComments": [
                 "No automated scanning is configured.",
+                "Scans run automatically every 12 hours.",
                 "Scans run automatically on a daily schedule."
+              ],
+              "enumFieldNames": [
+                "None",
+                "TwelveHours",
+                "Daily"
               ],
               "enumTypeName": "ScanSchedule"
             }
@@ -9074,8 +10472,7 @@
             },
             "required": [
               "admin",
-              "name",
-              "roleID"
+              "name"
             ],
             "type": "object"
           }
@@ -9098,6 +10495,69 @@
         "required": [
           "description",
           "name"
+        ],
+        "type": "object"
+      },
+      "CreateOrganizationInviteRequest": {
+        "description": "CreateOrganizationInviteRequest is for sending out invites to join a Pulumi organization.",
+        "properties": {
+          "email": {
+            "description": "The email address. Required for email-based invites, omitted when creating shareable invite links.",
+            "type": "string",
+            "x-order": 1
+          },
+          "role": {
+            "description": "Built-in role to assign to the invited member. When 'roleId' is also supplied it takes precedence and this field is ignored; prefer 'roleId' for new integrations.",
+            "enum": [
+              "member",
+              "admin",
+              "billing-manager"
+            ],
+            "type": "string",
+            "x-order": 2,
+            "x-pulumi-model-property": {
+              "enumComments": "Built-in role assignable through an organization invite.",
+              "enumFieldComments": [
+                "Regular organization member.",
+                "Organization administrator.",
+                "Billing administrator."
+              ],
+              "enumFieldNames": [
+                "Member",
+                "Admin",
+                "BillingManager"
+              ],
+              "enumTypeName": "OrganizationInviteRole"
+            }
+          },
+          "roleId": {
+            "description": "UUID of a role (built-in or custom) to assign to the invited member. Takes precedence over 'role' when both are supplied.",
+            "type": "string",
+            "x-order": 3
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "type": "object"
+      },
+      "CreateOrganizationInviteResponse": {
+        "description": "CreateOrganizationInviteResponse is the response type when creating a new invitation to join\na Pulumi organization.",
+        "properties": {
+          "acceptInviteUrl": {
+            "description": "The accept invite URL",
+            "type": "string",
+            "x-order": 2
+          },
+          "id": {
+            "description": "The unique identifier",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "acceptInviteUrl",
+          "id"
         ],
         "type": "object"
       },
@@ -9263,6 +10723,105 @@
             "type": "object"
           }
         ]
+      },
+      "CustomVCSIntegrationResponse": {
+        "description": "Response containing the details of a custom VCS integration, including its configuration, webhook endpoint, and configured repositories.",
+        "properties": {
+          "baseUrl": {
+            "description": "URL prefix for repositories covered by this integration",
+            "type": "string",
+            "x-order": 3
+          },
+          "created": {
+            "description": "ISO 8601 timestamp of when the integration was created",
+            "type": "string",
+            "x-order": 9
+          },
+          "environment": {
+            "description": "ESC environment reference in 'project/envName' format containing VCS credentials",
+            "type": "string",
+            "x-order": 4
+          },
+          "id": {
+            "description": "Unique identifier (UUID) for this integration",
+            "type": "string",
+            "x-order": 1
+          },
+          "modified": {
+            "description": "ISO 8601 timestamp of when the integration was last modified",
+            "type": "string",
+            "x-order": 10
+          },
+          "name": {
+            "description": "Human-readable name for the integration",
+            "type": "string",
+            "x-order": 2
+          },
+          "repositories": {
+            "description": "List of repositories configured on this integration",
+            "items": {
+              "$ref": "#/components/schemas/CustomVCSRepository"
+            },
+            "type": "array",
+            "x-order": 8
+          },
+          "vcsType": {
+            "description": "Version control system type",
+            "enum": [
+              "git",
+              "hg"
+            ],
+            "type": "string",
+            "x-order": 5,
+            "x-pulumi-model-property": {
+              "enumComments": "VCSType describes the version control system type for a custom VCS integration.",
+              "enumFieldComments": [
+                "Git version control system",
+                "Mercurial version control system"
+              ],
+              "enumTypeName": "VCSType"
+            }
+          },
+          "webhookSecret": {
+            "description": "HMAC secret for webhook signature verification. Only returned on integration creation; subsequent GET requests omit this field.",
+            "type": "string",
+            "x-order": 7
+          },
+          "webhookUrl": {
+            "description": "Full webhook endpoint URL that the external VCS should POST events to. This URL is generated by the service and includes the integration ID.",
+            "type": "string",
+            "x-order": 6
+          }
+        },
+        "required": [
+          "baseUrl",
+          "created",
+          "environment",
+          "id",
+          "modified",
+          "name",
+          "vcsType"
+        ],
+        "type": "object"
+      },
+      "CustomVCSRepository": {
+        "description": "A repository configured on a custom VCS integration. Each repository is identified by its name, which is joined with the integration's base URL to form the full clone URL.",
+        "properties": {
+          "displayName": {
+            "description": "Human-readable display name for the repository. If not provided, the name is used for display purposes.",
+            "type": "string",
+            "x-order": 2
+          },
+          "name": {
+            "description": "Repository name or path, joined with the integration's base URL to form the clone URL (e.g. 'myrepo' or 'subgroup/myrepo')",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
       },
       "CustomerManagedKey": {
         "description": "Represents customer managed key.",
@@ -9756,7 +11315,7 @@
             "x-order": 9
           },
           "id": {
-            "description": "ID is the internal PK of the Update.",
+            "description": "Unique identifier for this update.",
             "type": "string",
             "x-order": 1
           },
@@ -9768,27 +11327,42 @@
               "refresh",
               "rename",
               "destroy",
-              "import"
+              "import",
+              "Pupdate",
+              "Prefresh",
+              "Pdestroy",
+              "Pimport",
+              "Prename"
             ],
             "type": "string",
             "x-order": 7,
             "x-pulumi-model-property": {
               "enumComments": "UpdateKind is an enum for the type of update performed.\nShould generally mirror backend.UpdateKind, but we clone it in this package to add\nflexibility in case there is a breaking change in the backend-type.",
               "enumFieldComments": [
-                "UpdateUpdate is the prototypical Pulumi program update.",
-                "PreviewUpdate is a preview of an update, without impacting resources.",
-                "RefreshUpdate is an update that came from a refresh operation.",
-                "RenameUpdate is an update that changes the stack name or project name of a Pulumi program.\nNOTE: Do not remove this type - it is used by Pulumi Cloud code.",
-                "DestroyUpdate is an update which removes all resources.",
-                "StackImportUpdate is an update that entails importing a raw checkpoint file."
+                "A Pulumi program update.",
+                "A preview of an update, without impacting resources.",
+                "A refresh operation.",
+                "A rename of the stack or project name.\nNOTE: Do not remove this type - it is used by Pulumi Cloud code.",
+                "An update which removes all resources.",
+                "An update that entails importing a raw checkpoint file.",
+                "A preview of an update operation.",
+                "A preview of a refresh operation.",
+                "A preview of a destroy operation.",
+                "A preview of an import operation.",
+                "A preview of a rename operation."
               ],
               "enumFieldNames": [
-                "UpdateUpdate",
+                "Update",
+                "Preview",
+                "Refresh",
+                "Rename",
+                "Destroy",
+                "Import",
                 "PreviewUpdate",
-                "RefreshUpdate",
-                "RenameUpdate",
-                "DestroyUpdate",
-                "StackImportUpdate"
+                "PreviewRefresh",
+                "PreviewDestroy",
+                "PreviewImport",
+                "PreviewRename"
               ],
               "enumTypeName": "AppUpdateKind"
             }
@@ -9811,16 +11385,16 @@
             "x-pulumi-model-property": {
               "enumComments": "UpdateResult is an enum for the result of the update.\nShould generally mirror backend.UpdateResult, but we clone it in this package to add\nflexibility in case there is a breaking change in the backend-type.",
               "enumFieldComments": [
-                "NotStartedResult is for updates that have not started.",
-                "InProgressResult is for updates that have not yet completed.",
-                "SucceededResult is for updates that completed successfully.",
-                "FailedResult is for updates that have failed."
+                "The update has not started.",
+                "The update has not yet completed.",
+                "The update completed successfully.",
+                "The update has failed."
               ],
               "enumFieldNames": [
-                "NotStartedResult",
-                "InProgressResult",
-                "SucceededResult",
-                "FailedResult"
+                "NotStarted",
+                "InProgress",
+                "Succeeded",
+                "Failed"
               ],
               "enumTypeName": "AppUpdateResult"
             }
@@ -9832,7 +11406,7 @@
             "x-order": 4
           },
           "updateID": {
-            "description": "UpdateID is the underlying Update's ID from the CLI.",
+            "description": "Identifier of the underlying Pulumi CLI update operation.",
             "type": "string",
             "x-order": 2
           },
@@ -9938,6 +11512,7 @@
               "github-review-stack",
               "azure-devops-review-stack",
               "gitlab-review-stack",
+              "bitbucket-review-stack",
               "github-gitops"
             ],
             "type": "string",
@@ -9951,6 +11526,7 @@
                 "GitHubReviewStack",
                 "AzureDevOpsReviewStack",
                 "GitLabReviewStack",
+                "BitBucketReviewStack",
                 "GitHubGitOps"
               ],
               "enumTypeName": "DeploymentSettingsSource"
@@ -9994,6 +11570,11 @@
             "type": "integer",
             "x-order": 5
           },
+          "deployTags": {
+            "description": "Whether to deploy when a matching tag is pushed.",
+            "type": "boolean",
+            "x-order": 9
+          },
           "installationId": {
             "description": "The GitHub App installation ID.",
             "type": "string",
@@ -10021,6 +11602,22 @@
             "description": "The GitHub repository in the format owner/repo.",
             "type": "string",
             "x-order": 1
+          },
+          "reviewStackLabels": {
+            "description": "Gates review stack creation. When set, only pull requests carrying a matching label (exact, case-sensitive) create a review stack.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 8
+          },
+          "tagFilters": {
+            "description": "Glob patterns matching tag names that trigger a deployment when `deployTags` is true. Supports `!` prefix for negation (e.g. `!*-rc*` excludes release candidates). An empty list with `deployTags=true` matches all tags.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 10
           }
         },
         "type": "object"
@@ -10038,6 +11635,11 @@
             "format": "int64",
             "type": "integer",
             "x-order": 5
+          },
+          "deployTags": {
+            "description": "Whether to deploy when a matching tag is pushed.",
+            "type": "boolean",
+            "x-order": 9
           },
           "installationId": {
             "description": "The GitHub App installation ID.",
@@ -10066,6 +11668,22 @@
             "description": "The GitHub repository in the format owner/repo.",
             "type": "string",
             "x-order": 1
+          },
+          "reviewStackLabels": {
+            "description": "Gates review stack creation. When set, only pull requests carrying a matching label (exact, case-sensitive) create a review stack.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 8
+          },
+          "tagFilters": {
+            "description": "Glob patterns matching tag names that trigger a deployment when `deployTags` is true. Supports `!` prefix for negation. An empty list with `deployTags=true` matches all tags.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 10
           }
         },
         "required": [
@@ -10124,6 +11742,8 @@
         "discriminator": {
           "mapping": {
             "azure_devops": "#/components/schemas/DeploymentSettingsVCSAzureDevOps",
+            "bitbucket": "#/components/schemas/DeploymentSettingsVCSBitbucket",
+            "custom": "#/components/schemas/DeploymentSettingsVCSCustom",
             "github": "#/components/schemas/DeploymentSettingsVCSGitHub",
             "gitlab": "#/components/schemas/DeploymentSettingsVCSGitLab"
           },
@@ -10139,12 +11759,17 @@
             "description": "Specific pull request number to deploy (overrides automatic deployment)",
             "format": "int64",
             "type": "integer",
-            "x-order": 7
+            "x-order": 9
+          },
+          "deployTags": {
+            "description": "Whether to deploy when a matching tag is pushed.",
+            "type": "boolean",
+            "x-order": 3
           },
           "installationId": {
             "description": "VCS installation/integration ID linking to the VCS provider",
             "type": "string",
-            "x-order": 4
+            "x-order": 6
           },
           "paths": {
             "description": "Paths within the repository that trigger deployments when changed",
@@ -10152,12 +11777,12 @@
               "type": "string"
             },
             "type": "array",
-            "x-order": 3
+            "x-order": 4
           },
           "previewPullRequests": {
             "description": "Whether to create preview deployments for pull requests",
             "type": "boolean",
-            "x-order": 6
+            "x-order": 8
           },
           "provider": {
             "type": "string"
@@ -10165,12 +11790,20 @@
           "pullRequestTemplate": {
             "description": "Whether to use pull request templates for deployment PRs",
             "type": "boolean",
-            "x-order": 5
+            "x-order": 7
           },
           "repository": {
             "description": "The VCS repository reference (format varies by provider)",
             "type": "string",
             "x-order": 1
+          },
+          "tagFilters": {
+            "description": "Glob patterns matching tag names that trigger a deployment when `deployTags` is true. Supports `!` prefix for negation (e.g. `!*-rc*` excludes release candidates). An empty list with `deployTags=true` matches all tags.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 5
           }
         },
         "required": [
@@ -10189,6 +11822,28 @@
           }
         ]
       },
+      "DeploymentSettingsVCSBitbucket": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DeploymentSettingsVCS"
+          },
+          {
+            "description": "Bitbucket-specific VCS deployment settings.",
+            "type": "object"
+          }
+        ]
+      },
+      "DeploymentSettingsVCSCustom": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DeploymentSettingsVCS"
+          },
+          {
+            "description": "Custom VCS deployment settings for user-managed version control systems.",
+            "type": "object"
+          }
+        ]
+      },
       "DeploymentSettingsVCSGitHub": {
         "allOf": [
           {
@@ -10196,6 +11851,16 @@
           },
           {
             "description": "GitHub-specific VCS deployment settings.",
+            "properties": {
+              "reviewStackLabels": {
+                "description": "Gates review stack creation. When set, only pull requests carrying a matching label (exact, case-sensitive) create a review stack.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-order": 1
+              }
+            },
             "type": "object"
           }
         ]
@@ -10260,7 +11925,7 @@
         "description": "DeploymentSourceTemplate is like SourceContextTemplate but does not include the Auth data as we don't want to\ninclude that in the deployment response.",
         "properties": {
           "sourceUrl": {
-            "description": "SourceURL is the URL of the template source.",
+            "description": "The URL of the template source. Supports two URL schemes:\n\n**Registry-backed templates** use the `registry://` scheme with the format:\n`registry://templates/source/publisher/name[@version]`\n\n- `source`: The template source identifier (e.g., the registry source name)\n- `publisher`: The organization or user that published the template\n- `name`: The template name\n- `version`: Optional semver version (e.g., `1.0.0`). If omitted, defaults to the latest version\n\nExample: `registry://templates/pulumi/acme-corp/aws-vpc@2.1.0`\n\n**VCS-backed templates** use standard VCS URLs (GitHub, GitLab, Azure DevOps, etc.):\n`https://github.com/org/repo`",
             "type": "string",
             "x-order": 1
           }
@@ -10361,10 +12026,45 @@
       "DiscoveredResourceInfo": {
         "description": "A discovered resource with its indexed search representation.",
         "properties": {
+          "annotation": {
+            "$ref": "#/components/schemas/ResourceMigrationAnnotation",
+            "description": "User-created migration annotation, if any.",
+            "x-order": 9
+          },
+          "cloudProviderId": {
+            "description": "The cloud provider's physical identifier for this resource (e.g. an AWS ARN, S3 bucket name, or Azure resource path). For CloudFormation-discovered resources this is the CloudFormation PhysicalResourceID; for Terraform-backed stacks it is the Terraform-native resource ID.",
+            "type": "string",
+            "x-order": 4
+          },
           "managedBy": {
             "description": "The orchestrator or tool that manages this resource (e.g. 'CloudFormation', 'ARM', 'Pulumi').",
             "type": "string",
-            "x-order": 4
+            "x-order": 5
+          },
+          "migrationStatus": {
+            "description": "Migration status of the resource relative to the comparison stack.",
+            "enum": [
+              "Migrated",
+              "PulumiOnly",
+              "Ready",
+              "Pending",
+              "Unmapped",
+              "NotApplicable"
+            ],
+            "type": "string",
+            "x-order": 8,
+            "x-pulumi-model-property": {
+              "enumComments": "Migration status of a discovered resource relative to a comparison Pulumi stack. Migrated and PulumiOnly are only possible when the compareTo parameter is provided.",
+              "enumFieldComments": [
+                "Resource identity match found in the comparison stack.",
+                "Resource exists only in the comparison Pulumi stack.",
+                "Mapped to a Pulumi type with virtual state available.",
+                "Mapped to a Pulumi type but no virtual state yet.",
+                "No Pulumi type mapping exists for this resource.",
+                "Migration status is not applicable (e.g. stack or deployment containers)."
+              ],
+              "enumTypeName": "MigrationStatus"
+            }
           },
           "name": {
             "description": "A human-friendly resource name derived from the cloud provider",
@@ -10379,7 +12079,7 @@
           "providerType": {
             "description": "The mapped Pulumi provider type token (e.g. 'aws:s3/bucket:Bucket'). Omitted when the resource has not been mapped to a Pulumi type.",
             "type": "string",
-            "x-order": 5
+            "x-order": 6
           },
           "resource": {
             "$ref": "#/components/schemas/Resource",
@@ -10392,7 +12092,7 @@
             },
             "description": "The Pulumi-compatible state, if available.",
             "type": "object",
-            "x-order": 6
+            "x-order": 7
           }
         },
         "required": [
@@ -10820,6 +12520,11 @@
             "description": "The source range where the diagnostic occurred.",
             "x-order": 1
           },
+          "severity": {
+            "description": "The severity of the diagnostic: \"error\" or \"warning\".",
+            "type": "string",
+            "x-order": 4
+          },
           "summary": {
             "description": "A summary of the diagnostic message.",
             "type": "string",
@@ -10927,7 +12632,7 @@
           "activeChangeRequest": {
             "$ref": "#/components/schemas/ChangeRequestRef",
             "description": "ActiveChangeRequest contains information about any active change request for this environment.\nWill be nil if there is no active change request.",
-            "x-order": 2
+            "x-order": 3
           },
           "gatedActions": {
             "description": "GatedActions indicates which actions on this environment require change request approval.",
@@ -10935,7 +12640,7 @@
               "type": "string"
             },
             "type": "array",
-            "x-order": 3
+            "x-order": 4
           },
           "id": {
             "description": "Environment metadata follows other Pulumi Cloud \"Metadata\" fields and contains read-only information about the environment",
@@ -10945,11 +12650,17 @@
           "openRequestNeeded": {
             "description": "OpenRequestNeeded indicates whether an open request is currently needed in order to open the environment.",
             "type": "boolean",
-            "x-order": 4
+            "x-order": 5
+          },
+          "ownedBy": {
+            "$ref": "#/components/schemas/UserInfo",
+            "description": "The user with ownership of this environment",
+            "x-order": 2
           }
         },
         "required": [
-          "id"
+          "id",
+          "ownedBy"
         ],
         "type": "object"
       },
@@ -11885,7 +13596,7 @@
         "type": "object"
       },
       "FGARole": {
-        "description": "FGARole represents basic FGAC role information for organization members",
+        "description": "A role assigned to an organization member, identified by ID and name. The role may be a built-in role or a custom role.",
         "properties": {
           "id": {
             "description": "The unique identifier of the role.",
@@ -11908,38 +13619,6 @@
           "id",
           "modifiedAt",
           "name"
-        ],
-        "type": "object"
-      },
-      "FeedbackRequest": {
-        "description": "FeedbackRequest is the request body for submitting user feedback.",
-        "properties": {
-          "comment": {
-            "description": "A comment providing additional details about the feedback.",
-            "type": "string",
-            "x-order": 2
-          },
-          "feedbackKind": {
-            "description": "The kind of feedback (thumbs up or thumbs down).",
-            "enum": [
-              "thumbsup",
-              "thumbsdown"
-            ],
-            "type": "string",
-            "x-order": 1,
-            "x-pulumi-model-property": {
-              "enumComments": "The type of user feedback. Valid values: 'thumbsup', 'thumbsdown'.",
-              "enumFieldNames": [
-                "ThumbsUp",
-                "ThumbsDown"
-              ],
-              "enumTypeName": "FeedbackKind"
-            }
-          }
-        },
-        "required": [
-          "comment",
-          "feedbackKind"
         ],
         "type": "object"
       },
@@ -12022,29 +13701,6 @@
           }
         ]
       },
-      "GetConversationResponse": {
-        "description": "Response body for retrieving a conversation and its messages.",
-        "properties": {
-          "conversation": {
-            "$ref": "#/components/schemas/Conversation",
-            "description": "The conversation details",
-            "x-order": 1
-          },
-          "messages": {
-            "description": "The messages in the conversation",
-            "items": {
-              "$ref": "#/components/schemas/Message"
-            },
-            "type": "array",
-            "x-order": 2
-          }
-        },
-        "required": [
-          "conversation",
-          "messages"
-        ],
-        "type": "object"
-      },
       "GetDeploymentResponse": {
         "description": "GetDeploymentResponse is the response from the API when getting a single Deployment.",
         "properties": {
@@ -12059,7 +13715,7 @@
             "x-order": 2
           },
           "id": {
-            "description": "ID is the internal PK of the Deployment.",
+            "description": "Unique identifier for this deployment.",
             "type": "string",
             "x-order": 1
           },
@@ -12069,7 +13725,7 @@
             "x-order": 10
           },
           "jobs": {
-            "description": "Jobs make up all the Jobs of the Deployment.",
+            "description": "Jobs make up all the Jobs of the Deployment. Omitted for deployments that have not started yet.",
             "items": {
               "$ref": "#/components/schemas/DeploymentJob"
             },
@@ -12088,7 +13744,7 @@
             "x-order": 3
           },
           "pulumiOperation": {
-            "description": "PulumiOperation is the operation that was performed.",
+            "description": "PulumiOperation is the operation that was performed. Omitted for historical deployments that predate this field.",
             "enum": [
               "update",
               "preview",
@@ -12160,10 +13816,8 @@
         "required": [
           "created",
           "id",
-          "jobs",
           "latestVersion",
           "modified",
-          "pulumiOperation",
           "requestedBy",
           "status",
           "version"
@@ -12265,21 +13919,6 @@
         ],
         "type": "object"
       },
-      "GetMessageCountResponse": {
-        "description": "Response body for retrieving the count of messages sent.",
-        "properties": {
-          "messages_sent": {
-            "description": "The number of messages sent",
-            "format": "int64",
-            "type": "integer",
-            "x-order": 1
-          }
-        },
-        "required": [
-          "messages_sent"
-        ],
-        "type": "object"
-      },
       "GetNaturalLanguageQueryResponse": {
         "description": "Response body for a natural language query translation.",
         "properties": {
@@ -12354,6 +13993,371 @@
           "hasUpstreamError",
           "orgHasTemplates",
           "templates"
+        ],
+        "type": "object"
+      },
+      "GetOrganizationMemberTeamsResponse": {
+        "description": "GetOrganizationMemberTeamsResponse lists all teams a user has access to.",
+        "properties": {
+          "teams": {
+            "description": "The names of teams this member belongs to within the organization.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "type": "object"
+      },
+      "GetPackageDocsResponse": {
+        "description": "API documentation for a single resource or function.",
+        "properties": {
+          "description": {
+            "description": "Description as an array of content nodes. Chooser nodes are resolved.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryContentNode"
+            },
+            "type": "array",
+            "x-order": 7
+          },
+          "inputs": {
+            "description": "Input properties.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryDocsProperty"
+            },
+            "type": "array",
+            "x-order": 8
+          },
+          "kind": {
+            "description": "Whether this is a 'resource' or 'function'.",
+            "type": "string",
+            "x-order": 4
+          },
+          "language": {
+            "description": "Rendering target for code snippets and resolved names. Individual content may fall back to another available language when the target is missing. Never null.",
+            "type": "string",
+            "x-order": 5
+          },
+          "name": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Display name keyed by language.",
+            "type": "object",
+            "x-order": 6
+          },
+          "navUrl": {
+            "description": "Path to the package navigation endpoint for this version.",
+            "type": "string",
+            "x-order": 2
+          },
+          "outputs": {
+            "description": "Output properties.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryDocsProperty"
+            },
+            "type": "array",
+            "x-order": 9
+          },
+          "supportingTypes": {
+            "description": "Supporting types referenced by inputs and outputs (inlined, not referenced by index).",
+            "items": {
+              "$ref": "#/components/schemas/RegistryDocsSupportingType"
+            },
+            "type": "array",
+            "x-order": 10
+          },
+          "typeToken": {
+            "description": "The Pulumi type token identifying this resource or function (e.g. 'random:index/randomPassword:RandomPassword').",
+            "type": "string",
+            "x-order": 3
+          },
+          "version": {
+            "description": "The resolved semantic version of the package.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "description",
+          "kind",
+          "language",
+          "name",
+          "navUrl",
+          "typeToken",
+          "version"
+        ],
+        "type": "object"
+      },
+      "GetPackageExamplesResponse": {
+        "description": "Code examples aggregated across a package's resources and functions. Each example carries its own 'typeToken' and 'kind', filtered by 'q' and capped by 'limit'.",
+        "properties": {
+          "examples": {
+            "description": "Examples sorted by type token, then by position within each type token. Capped at 'limit'.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryExample"
+            },
+            "type": "array",
+            "x-order": 4
+          },
+          "language": {
+            "description": "Resolved snippet language.",
+            "type": "string",
+            "x-order": 3
+          },
+          "navUrl": {
+            "description": "Path to the package navigation endpoint.",
+            "type": "string",
+            "x-order": 2
+          },
+          "totalCount": {
+            "description": "Total examples matching the query before 'limit' was applied.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 5
+          },
+          "version": {
+            "description": "Resolved semantic version.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "examples",
+          "language",
+          "navUrl",
+          "totalCount",
+          "version"
+        ],
+        "type": "object"
+      },
+      "GetPackageInstallationResponse": {
+        "description": "Installation configuration content for a registry package, structured as an ordered list of content nodes. When a language or OS filter is applied, language- and OS-specific content is collapsed to the requested value. Returns 404 if the package does not include installation configuration.",
+        "properties": {
+          "content": {
+            "description": "Ordered list of content nodes composing the installation configuration document.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryContentNode"
+            },
+            "type": "array",
+            "x-order": 5
+          },
+          "language": {
+            "description": "The language the content was filtered for, if a language filter was applied.",
+            "type": "string",
+            "x-order": 2
+          },
+          "navUrl": {
+            "description": "Path to the package navigation endpoint for this version.",
+            "type": "string",
+            "x-order": 4
+          },
+          "os": {
+            "description": "The operating system the content was filtered for, if an OS filter was applied.",
+            "type": "string",
+            "x-order": 3
+          },
+          "version": {
+            "description": "The resolved semantic version of the package.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "content",
+          "navUrl",
+          "version"
+        ],
+        "type": "object"
+      },
+      "GetPackageNavItem": {
+        "description": "A resource or function entry in the package navigation tree.",
+        "properties": {
+          "name": {
+            "description": "The display name, resolved for the requested language.",
+            "type": "string",
+            "x-order": 2
+          },
+          "typeToken": {
+            "description": "The Pulumi type token identifying this resource or function (e.g. 'random:index/randomPassword:RandomPassword').",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "name",
+          "typeToken"
+        ],
+        "type": "object"
+      },
+      "GetPackageNavModule": {
+        "description": "A module within a package navigation. Modules are flat: names like 's3/bucket' are not split into nested children.",
+        "properties": {
+          "functions": {
+            "description": "Functions in this module. Returned only when 'depth=full' is set.",
+            "items": {
+              "$ref": "#/components/schemas/GetPackageNavItem"
+            },
+            "type": "array",
+            "x-order": 3
+          },
+          "functionsTotal": {
+            "description": "Total functions in this module, independent of 'q'.",
+            "format": "int32",
+            "type": "integer",
+            "x-order": 5
+          },
+          "name": {
+            "description": "Module display name, resolved for the requested language. May contain '/' (e.g. 's3/bucket').",
+            "type": "string",
+            "x-order": 1
+          },
+          "resources": {
+            "description": "Resources in this module. Returned only when 'depth=full' is set.",
+            "items": {
+              "$ref": "#/components/schemas/GetPackageNavItem"
+            },
+            "type": "array",
+            "x-order": 2
+          },
+          "resourcesTotal": {
+            "description": "Total resources in this module, independent of 'q'.",
+            "format": "int32",
+            "type": "integer",
+            "x-order": 4
+          }
+        },
+        "required": [
+          "functionsTotal",
+          "name",
+          "resourcesTotal"
+        ],
+        "type": "object"
+      },
+      "GetPackageNavResponse": {
+        "description": "Package navigation: a flat list of modules, each with resources and functions.",
+        "properties": {
+          "description": {
+            "description": "Short description of the package.",
+            "type": "string",
+            "x-order": 6
+          },
+          "docsUrlTemplate": {
+            "description": "URL template for the docs endpoint. Substitute '{typeToken}' with a URL-encoded Pulumi type token from a navigation item.",
+            "type": "string",
+            "x-order": 11
+          },
+          "installationUrl": {
+            "description": "Path to the installation configuration endpoint, if present.",
+            "type": "string",
+            "x-order": 10
+          },
+          "language": {
+            "description": "Rendering target for resolved names. Individual content may fall back to another available language when the target is missing.",
+            "type": "string",
+            "x-order": 7
+          },
+          "modules": {
+            "description": "Modules in this package.",
+            "items": {
+              "$ref": "#/components/schemas/GetPackageNavModule"
+            },
+            "type": "array",
+            "x-order": 12
+          },
+          "modulesTotal": {
+            "description": "Total number of modules in the package, independent of 'q'.",
+            "format": "int32",
+            "type": "integer",
+            "x-order": 13
+          },
+          "name": {
+            "description": "Package name (e.g. 'aws').",
+            "type": "string",
+            "x-order": 3
+          },
+          "packageVersionUrl": {
+            "description": "Path to the package version metadata endpoint.",
+            "type": "string",
+            "x-order": 8
+          },
+          "publisher": {
+            "description": "Package publisher (e.g. 'pulumi').",
+            "type": "string",
+            "x-order": 2
+          },
+          "readmeUrl": {
+            "description": "Path to the README endpoint.",
+            "type": "string",
+            "x-order": 9
+          },
+          "source": {
+            "description": "Package source (e.g. 'pulumi').",
+            "type": "string",
+            "x-order": 1
+          },
+          "title": {
+            "description": "Display title.",
+            "type": "string",
+            "x-order": 5
+          },
+          "version": {
+            "description": "Resolved semantic version.",
+            "type": "string",
+            "x-order": 4
+          }
+        },
+        "required": [
+          "docsUrlTemplate",
+          "modules",
+          "modulesTotal",
+          "name",
+          "packageVersionUrl",
+          "publisher",
+          "readmeUrl",
+          "source",
+          "title",
+          "version"
+        ],
+        "type": "object"
+      },
+      "GetPackageReadmeResponse": {
+        "description": "README content for a registry package, structured as an ordered list of content nodes. When a language or OS filter is applied, language- and OS-specific content is collapsed to the requested value.",
+        "properties": {
+          "content": {
+            "description": "Ordered list of content nodes composing the README document.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryContentNode"
+            },
+            "type": "array",
+            "x-order": 5
+          },
+          "language": {
+            "description": "The language the content was filtered for, if a language filter was applied.",
+            "type": "string",
+            "x-order": 2
+          },
+          "navUrl": {
+            "description": "Path to the package navigation endpoint for this version.",
+            "type": "string",
+            "x-order": 4
+          },
+          "os": {
+            "description": "The operating system the content was filtered for, if an OS filter was applied.",
+            "type": "string",
+            "x-order": 3
+          },
+          "version": {
+            "description": "The resolved semantic version of the package.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "content",
+          "navUrl",
+          "version"
         ],
         "type": "object"
       },
@@ -12497,6 +14501,14 @@
             },
             "type": "array",
             "x-order": 1
+          },
+          "tagKeys": {
+            "description": "The list of tag keys present in the breakdown entries. Only present when a tag breakdown is requested.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 2
           }
         },
         "required": [
@@ -12527,7 +14539,6 @@
           }
         },
         "required": [
-          "continuationToken",
           "items",
           "service"
         ],
@@ -12732,6 +14743,24 @@
           },
           {
             "description": "Response body for retrieving a single template.",
+            "type": "object"
+          }
+        ]
+      },
+      "GetTerraformModuleResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TerraformModuleVersion"
+          },
+          {
+            "description": "Response containing the detail for a single Terraform module version.",
+            "properties": {
+              "terraformSourceAddress": {
+                "description": "The Terraform/OpenTofu source address (\"<host>/<namespace>/<name>/<system>\") used to consume the module from a module block or `pulumi package add terraform-module`. Empty when the registry host is not configured.",
+                "type": "string",
+                "x-order": 1
+              }
+            },
             "type": "object"
           }
         ]
@@ -12972,6 +15001,65 @@
         },
         "type": "object"
       },
+      "GitHubEnterpriseAuthorizeURLResponse": {
+        "description": "GitHubEnterpriseAuthorizeURLResponse carries the GitHub Enterprise authorization URL the console should redirect the user to in order to link their GitHub Enterprise identity.",
+        "properties": {
+          "authorizeUrl": {
+            "description": "The fully-formed GitHub Enterprise OAuth authorization URL, including client_id, redirect_uri, and a signed state parameter.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "authorizeUrl"
+        ],
+        "type": "object"
+      },
+      "GitHubEnterpriseLinkedMembersResponse": {
+        "description": "GitHubEnterpriseLinkedMembersResponse lists the organization members who have linked a GitHub Enterprise identity for a given integration's host.",
+        "properties": {
+          "linkedLogins": {
+            "description": "The github.com logins of organization members who have linked a GitHub Enterprise identity on the integration's host. Members whose login is absent are not linked.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "linkedLogins"
+        ],
+        "type": "object"
+      },
+      "GitHubEnterpriseUserIdentityResponse": {
+        "description": "GitHubEnterpriseUserIdentityResponse describes the GitHub Enterprise identity a user has linked for a given integration's host.",
+        "properties": {
+          "connectedAt": {
+            "description": "The time the identity was linked.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 3
+          },
+          "githubId": {
+            "description": "The immutable numeric GitHub Enterprise user ID of the linked identity.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 2
+          },
+          "login": {
+            "description": "The GitHub Enterprise login (username) of the linked identity.",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "connectedAt",
+          "githubId",
+          "login"
+        ],
+        "type": "object"
+      },
       "GitHubIntegrationDetails": {
         "description": "GitHubIntegrationDetails describes a single GitHub App installation.",
         "properties": {
@@ -12997,10 +15085,20 @@
             "type": "string",
             "x-order": 8
           },
+          "disableCodeAccessForReviews": {
+            "description": "Whether code access for AI reviews is disabled for this installation.",
+            "type": "boolean",
+            "x-order": 12
+          },
           "disableDetailedDiff": {
             "description": "Whether detailed property-level diffs are disabled for PR comments.",
             "type": "boolean",
             "x-order": 11
+          },
+          "disableDraftPRComments": {
+            "description": "Whether PR comments are disabled while a pull request is in draft.",
+            "type": "boolean",
+            "x-order": 13
           },
           "disableNeoSummaries": {
             "description": "Whether Neo AI summaries are disabled for this installation.",
@@ -13015,22 +15113,27 @@
           "ghUrls": {
             "$ref": "#/components/schemas/GitHubAppURLs",
             "description": "URL to configure repository access for this GitHub App installation.",
-            "x-order": 15
+            "x-order": 18
           },
           "hasContentsPermission": {
             "description": "Whether the installation has the 'contents' permission.",
             "type": "boolean",
-            "x-order": 13
+            "x-order": 16
           },
           "hasMembersPermission": {
             "description": "Whether the installation has the 'members' permission (only relevant for organization accounts).",
             "type": "boolean",
-            "x-order": 12
+            "x-order": 15
           },
           "id": {
             "description": "The Pulumi ID of the GitHub App installation.",
             "type": "string",
             "x-order": 2
+          },
+          "individualAuthEnabled": {
+            "description": "Whether per-user (individual) GitHub Enterprise authentication is enabled. Only applies to self-hosted GitHub Enterprise installations.",
+            "type": "boolean",
+            "x-order": 14
           },
           "installationID": {
             "description": "The GitHub installation ID.",
@@ -13054,10 +15157,11 @@
               "$ref": "#/components/schemas/GitHubAppPermissionRequirement"
             },
             "type": "array",
-            "x-order": 14
+            "x-order": 17
           }
         },
         "required": [
+          "disableCodeAccessForReviews",
           "disableDetailedDiff",
           "disableNeoSummaries",
           "disablePRComments",
@@ -13156,10 +15260,20 @@
       "GitHubSettingsRequest": {
         "description": "GitHubSettingsRequest describes settings for a GitHub App installation.",
         "properties": {
+          "disableCodeAccessForReviews": {
+            "description": "Whether to disable code access for AI reviews",
+            "type": "boolean",
+            "x-order": 4
+          },
           "disableDetailedDiff": {
             "description": "Whether to disable detailed property-level diffs in PR comments",
             "type": "boolean",
             "x-order": 3
+          },
+          "disableDraftPRComments": {
+            "description": "Whether to disable PR comments while a pull request is in draft",
+            "type": "boolean",
+            "x-order": 5
           },
           "disableNeoSummaries": {
             "description": "Whether to disable Neo AI summaries on PRs",
@@ -13170,6 +15284,11 @@
             "description": "Whether to disable PR comments from the Pulumi GitHub App",
             "type": "boolean",
             "x-order": 1
+          },
+          "individualAuthEnabled": {
+            "description": "Whether per-user (individual) GitHub Enterprise authentication is enabled. Only applies to self-hosted GitHub Enterprise installations.",
+            "type": "boolean",
+            "x-order": 6
           }
         },
         "type": "object"
@@ -13288,27 +15407,27 @@
           "authUser": {
             "$ref": "#/components/schemas/User",
             "description": "The Pulumi user whose GitLab authentication token is being used, if applicable.",
-            "x-order": 8
+            "x-order": 9
           },
           "avatarUrl": {
             "description": "The URL of the GitLab group's avatar image.",
             "type": "string",
-            "x-order": 4
+            "x-order": 5
           },
           "disableDetailedDiff": {
             "description": "Whether detailed property-level diffs are disabled for PR comments.",
             "type": "boolean",
-            "x-order": 12
+            "x-order": 13
           },
           "disableNeoSummaries": {
             "description": "Whether Neo AI summaries are disabled for this integration.",
             "type": "boolean",
-            "x-order": 11
+            "x-order": 12
           },
           "disablePRComments": {
             "description": "Whether PR comments are disabled for this integration.",
             "type": "boolean",
-            "x-order": 10
+            "x-order": 11
           },
           "gitLabGroupId": {
             "description": "The GitLab group ID linked to this integration.",
@@ -13319,18 +15438,23 @@
           "gitLabOrg": {
             "$ref": "#/components/schemas/GitLabAppOrganization",
             "description": "Metadata about the GitLab group linked to this integration.",
-            "x-order": 7
+            "x-order": 8
           },
           "groupAccessTokenExpiration": {
             "description": "The expiration date of the group access token, if one is being used for authentication.",
             "format": "date-time",
             "type": "string",
-            "x-order": 9
+            "x-order": 10
           },
           "groupName": {
             "description": "The display name of the GitLab group.",
             "type": "string",
             "x-order": 3
+          },
+          "groupPath": {
+            "description": "The URL-safe path of the GitLab group (e.g. 'parent-group/child-group').",
+            "type": "string",
+            "x-order": 4
           },
           "id": {
             "description": "The unique identifier of the GitLab integration.",
@@ -13340,12 +15464,12 @@
           "installed": {
             "description": "Whether the integration has been fully installed.",
             "type": "boolean",
-            "x-order": 5
+            "x-order": 6
           },
           "valid": {
             "description": "Whether the integration is currently valid (tokens, hooks, etc.).",
             "type": "boolean",
-            "x-order": 6
+            "x-order": 7
           }
         },
         "required": [
@@ -13440,7 +15564,7 @@
           "agentPoolID": {
             "description": "The ID of the agent pool to run account discovery workflows.\nIf not specified, discovery will use the default agent pool.",
             "type": "string",
-            "x-order": 7
+            "x-order": 8
           },
           "id": {
             "description": "ID of the account.",
@@ -13452,40 +15576,46 @@
             "type": "string",
             "x-order": 2
           },
+          "ownedBy": {
+            "$ref": "#/components/schemas/UserInfo",
+            "description": "The user with ownership of this Insights account",
+            "x-order": 3
+          },
           "provider": {
             "description": "The cloud provider for the account (e.g., aws, gcp, azure-native).",
             "type": "string",
-            "x-order": 3
+            "x-order": 4
           },
           "providerConfig": {
             "description": "Provider-specific configuration for the account.",
             "type": "object",
-            "x-order": 8
+            "x-order": 9
           },
           "providerEnvRef": {
             "description": "Reference to an ESC environment containing provider credentials,\nin the format 'project/environment' with an optional @version suffix.",
             "type": "string",
-            "x-order": 5
+            "x-order": 6
           },
           "providerVersion": {
             "description": "The version of the Pulumi provider package used for discovery.",
             "type": "string",
-            "x-order": 4
+            "x-order": 5
           },
           "scanStatus": {
             "$ref": "#/components/schemas/ScanStatus",
             "description": "Status of the last discovery scan for this account.",
-            "x-order": 9
+            "x-order": 10
           },
           "scheduledScanEnabled": {
             "description": "If true, the account is scheduled for recurring discovery.",
             "type": "boolean",
-            "x-order": 6
+            "x-order": 7
           }
         },
         "required": [
           "id",
           "name",
+          "ownedBy",
           "provider",
           "scheduledScanEnabled"
         ],
@@ -14104,6 +16234,11 @@
             },
             "type": "array",
             "x-order": 1
+          },
+          "defaultAgentPoolID": {
+            "description": "The ID of the organization's default agent pool. Omitted if the organization uses the Pulumi Hosted Pool.",
+            "type": "string",
+            "x-order": 2
           }
         },
         "required": [
@@ -14167,6 +16302,23 @@
             "description": "The list of Azure DevOps integrations.",
             "items": {
               "$ref": "#/components/schemas/AzureDevOpsIntegrationDetails"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "integrations"
+        ],
+        "type": "object"
+      },
+      "ListBitBucketIntegrationsResponse": {
+        "description": "Response containing a list of BitBucket integrations for an organization.",
+        "properties": {
+          "integrations": {
+            "description": "The list of BitBucket integrations.",
+            "items": {
+              "$ref": "#/components/schemas/BitBucketIntegrationDetails"
             },
             "type": "array",
             "x-order": 1
@@ -14263,20 +16415,20 @@
         ],
         "type": "object"
       },
-      "ListConversationsResponse": {
-        "description": "Response containing a list of conversations.",
+      "ListCustomVCSIntegrationsResponse": {
+        "description": "Response containing a list of all custom VCS integrations configured for an organization.",
         "properties": {
-          "conversations": {
-            "description": "The list of conversations",
+          "integrations": {
+            "description": "List of custom VCS integrations for the organization",
             "items": {
-              "$ref": "#/components/schemas/Conversation"
+              "$ref": "#/components/schemas/CustomVCSIntegrationResponse"
             },
             "type": "array",
             "x-order": 1
           }
         },
         "required": [
-          "conversations"
+          "integrations"
         ],
         "type": "object"
       },
@@ -14306,7 +16458,7 @@
             "x-order": 2
           },
           "id": {
-            "description": "ID is the internal PK of the Deployment.",
+            "description": "Unique identifier for this deployment.",
             "type": "string",
             "x-order": 1
           },
@@ -15411,7 +17563,6 @@
           }
         },
         "required": [
-          "continuationToken",
           "services"
         ],
         "type": "object"
@@ -15587,6 +17738,50 @@
         ],
         "type": "object"
       },
+      "ListTerraformModuleVersionsResponse": {
+        "description": "Response containing the version history of a Terraform module, latest first.",
+        "properties": {
+          "continuationToken": {
+            "description": "An opaque token for fetching the next page of results.",
+            "type": "string",
+            "x-order": 2
+          },
+          "versions": {
+            "description": "The list of module versions, ordered by version descending (latest first).",
+            "items": {
+              "$ref": "#/components/schemas/TerraformModuleVersion"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "versions"
+        ],
+        "type": "object"
+      },
+      "ListTerraformModulesResponse": {
+        "description": "Response containing a paginated list of Terraform modules.",
+        "properties": {
+          "continuationToken": {
+            "description": "An opaque token for fetching the next page of results.",
+            "type": "string",
+            "x-order": 2
+          },
+          "modules": {
+            "description": "The list of Terraform modules.",
+            "items": {
+              "$ref": "#/components/schemas/TerraformModule"
+            },
+            "type": "array",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "modules"
+        ],
+        "type": "object"
+      },
       "ListUsersWithRoleResponse": {
         "description": "ListUsersWithRoleResponse is the shape of the response when listing users with a given role within an organization.",
         "properties": {
@@ -15671,59 +17866,139 @@
         },
         "type": "object"
       },
-      "Message": {
-        "description": "Message represents a single message in a conversation.",
+      "NeoMemberUsageCap": {
+        "description": "A single member's monthly Neo usage cap, returned by the self-serve UpdateNeoMemberUsageCap endpoint. Denominated in cents (cents/month). The cap stacks with the org-level cap: a member is stopped when either cap is reached.",
         "properties": {
-          "created": {
-            "description": "The timestamp when the message was created, in ISO 8601 format.",
-            "type": "string",
+          "capCents": {
+            "description": "Monthly cap in US-dollar cents. Always strictly positive; \"no cap\" is the absence of a row (removed via DeleteNeoMemberUsageCap).",
+            "format": "int64",
+            "type": "integer",
             "x-order": 2
           },
-          "id": {
-            "description": "The unique identifier of the message.",
-            "type": "string",
-            "x-order": 1
-          },
-          "message": {
-            "description": "The text body of the message.",
-            "type": "string",
-            "x-order": 5
-          },
-          "message_schema_version": {
-            "description": "The schema version of the message format.",
-            "type": "string",
-            "x-order": 6
-          },
-          "model": {
-            "description": "The AI model used to generate this message.",
+          "updatedAt": {
+            "description": "Time when the cap was last updated.",
+            "format": "date-time",
             "type": "string",
             "x-order": 3
           },
-          "parent_conversation_message_id": {
-            "description": "The ID of the parent conversation message, if this is a reply.",
+          "userID": {
+            "description": "The user the cap applies to.",
             "type": "string",
-            "x-order": 8
-          },
-          "role": {
-            "description": "The role of the message author (e.g. user, assistant).",
-            "type": "string",
-            "x-order": 4
-          },
-          "skills": {
-            "description": "A JSON-encoded string of skill invocations associated with this message.",
-            "type": "string",
-            "x-order": 7
+            "x-order": 1
           }
         },
         "required": [
-          "created",
-          "id",
-          "message",
-          "message_schema_version",
-          "model",
-          "parent_conversation_message_id",
-          "role",
-          "skills"
+          "capCents",
+          "updatedAt",
+          "userID"
+        ],
+        "type": "object"
+      },
+      "NeoMemberUsageCapEntry": {
+        "description": "A single organization member with their per-member Neo usage cap, month-to-date Neo spend, and effective limit. An entry of ListNeoMemberUsageCaps.",
+        "properties": {
+          "amountUsedCents": {
+            "description": "The member's Neo spend in US-dollar cents so far in the current monthly cap window.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 7
+          },
+          "avatarURL": {
+            "description": "URL of the member's avatar image.",
+            "type": "string",
+            "x-order": 4
+          },
+          "effectiveLimitCents": {
+            "description": "The limit that binds first: the smaller of the per-member and org-level caps in US-dollar cents. Null when the member has neither cap (unbounded).",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 8
+          },
+          "email": {
+            "description": "The member's email address.",
+            "type": "string",
+            "x-order": 5
+          },
+          "login": {
+            "description": "The member's login.",
+            "type": "string",
+            "x-order": 2
+          },
+          "name": {
+            "description": "The member's display name.",
+            "type": "string",
+            "x-order": 3
+          },
+          "perMemberCapCents": {
+            "description": "The member's per-member monthly Neo usage cap in US-dollar cents, or null when no per-member cap is set (the member is bounded only by the org-level cap, if any).",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 6
+          },
+          "userID": {
+            "description": "The member's user ID. This is the identifier the PUT and DELETE per-member cap endpoints key on (SSO-safe, unlike login).",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "amountUsedCents",
+          "avatarURL",
+          "email",
+          "login",
+          "name",
+          "userID"
+        ],
+        "type": "object"
+      },
+      "NeoMemberUsageCaps": {
+        "description": "Org members joined with their per-member Neo usage cap, month-to-date Neo spend, and effective limit, returned by the self-serve ListNeoMemberUsageCaps endpoint. Every member of the organization is present; members without a per-member cap have a null perMemberCapCents.",
+        "properties": {
+          "members": {
+            "description": "One entry per organization member.",
+            "items": {
+              "$ref": "#/components/schemas/NeoMemberUsageCapEntry"
+            },
+            "type": "array",
+            "x-order": 2
+          },
+          "orgCapCents": {
+            "description": "The org-level monthly Neo usage cap in US-dollar cents, or null when the organization has no org-level cap. Provided for context — a member's effective limit is the smaller of their per-member cap and this.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "members"
+        ],
+        "type": "object"
+      },
+      "NeoUsageCap": {
+        "description": "Org admin-configured monthly Neo usage cap, returned by the self-serve GetNeoUsageCap and UpdateNeoUsageCap endpoints. Denominated in cents (cents/month). A 204 (no content) from GetNeoUsageCap means no cap is set — the org default.",
+        "properties": {
+          "capCents": {
+            "description": "Monthly cap in US-dollar cents. Always strictly positive; \"no cap\" is the absence of a row (GetNeoUsageCap returns 204).",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 1
+          },
+          "notificationsEnabled": {
+            "description": "Whether threshold-warning emails (50/80/95/100% of the cap) are sent to billing admins. True unless the admin has turned them off.",
+            "type": "boolean",
+            "x-order": 3
+          },
+          "updatedAt": {
+            "description": "Time when the cap was last updated.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "capCents",
+          "notificationsEnabled",
+          "updatedAt"
         ],
         "type": "object"
       },
@@ -16049,7 +18324,7 @@
             "x-order": 1
           },
           "operation": {
-            "description": "Operation is what we plan on doing.",
+            "description": "The Pulumi operation to perform (e.g. update, preview, refresh, destroy).",
             "enum": [
               "update",
               "preview",
@@ -16116,7 +18391,7 @@
             "x-order": 3
           },
           "sessionName": {
-            "description": "The name of the assume-role session.",
+            "description": "The name of the assume-role session, sent to AWS STS as RoleSessionName. Supports ${var} placeholders for ${organization.name}, ${project.name}, ${stack.name}, ${operation}, ${deployment.version}, and ${deployment.id}. Recommended: include ${deployment.version} so each run is traceable in AWS CloudTrail (for example, 'pulumi-${deployment.version}'). AWS caps RoleSessionName at 64 characters; if a rendered template would exceed that, the name variables (organization, project, stack) are truncated to fit while ${operation}, ${deployment.version}, and ${deployment.id} are preserved.",
             "type": "string",
             "x-order": 4
           }
@@ -16480,7 +18755,7 @@
           "deletedAt": {
             "description": "The ISO 8601 timestamp when the environment was soft-deleted, or null if not deleted.",
             "type": "string",
-            "x-order": 8
+            "x-order": 9
           },
           "id": {
             "description": "The unique identifier of the environment.",
@@ -16490,7 +18765,7 @@
           "links": {
             "$ref": "#/components/schemas/EnvironmentLinks",
             "description": "Hypermedia links related to the environment.",
-            "x-order": 9
+            "x-order": 10
           },
           "modified": {
             "description": "The ISO 8601 timestamp when the environment was last modified.",
@@ -16507,6 +18782,11 @@
             "type": "string",
             "x-order": 2
           },
+          "ownedBy": {
+            "$ref": "#/components/schemas/UserInfo",
+            "description": "The user with ownership of this environment",
+            "x-order": 7
+          },
           "project": {
             "description": "The project name that contains this environment, if project-scoped.",
             "type": "string",
@@ -16514,13 +18794,13 @@
           },
           "referrerMetadata": {
             "$ref": "#/components/schemas/EnvironmentReferrerMetadata",
-            "description": "Metadata about what refers to this environment.",
-            "x-order": 10
+            "description": "Deprecated. No longer populated; always returns zero counts.",
+            "x-order": 11
           },
           "settings": {
             "$ref": "#/components/schemas/EnvironmentSettings",
             "description": "Configuration settings for the environment, such as deletion protection.",
-            "x-order": 11
+            "x-order": 12
           },
           "tags": {
             "additionalProperties": {
@@ -16528,7 +18808,7 @@
             },
             "description": "User-defined key-value tags associated with the environment for organization and filtering.",
             "type": "object",
-            "x-order": 7
+            "x-order": 8
           }
         },
         "required": [
@@ -16537,9 +18817,70 @@
           "modified",
           "name",
           "organization",
+          "ownedBy",
           "referrerMetadata",
           "settings",
           "tags"
+        ],
+        "type": "object"
+      },
+      "OrgNeoTokenBudget": {
+        "description": "The current Neo-token allowance and consumption for an organization.",
+        "properties": {
+          "baseAllowanceTokens": {
+            "description": "Plan-derived base allowance for the current window, in Neo tokens.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 2
+          },
+          "consumedTokens": {
+            "description": "Total Neo tokens consumed in the current window.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 4
+          },
+          "effectiveAllowanceTokens": {
+            "description": "Allowance for the current window, in Neo tokens. Includes any active bonus on top of the base allowance.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 3
+          },
+          "exhausted": {
+            "description": "True when consumedTokens has reached effectiveAllowanceTokens for the current window.",
+            "type": "boolean",
+            "x-order": 6
+          },
+          "windowEnd": {
+            "description": "Unix epoch timestamp (seconds) when the current window ends and the consumed counter resets. Zero when the window does not reset.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 5
+          },
+          "windowKind": {
+            "description": "Kind of cap window applied to the org.",
+            "enum": [
+              "trial",
+              "individual"
+            ],
+            "type": "string",
+            "x-order": 1,
+            "x-pulumi-model-property": {
+              "enumComments": "Kind of cap window applied to a Neo-token budget.",
+              "enumFieldComments": [
+                "One-time allowance across the duration of a subscription trial.",
+                "Per calendar-month allowance for a single-user free organization."
+              ],
+              "enumTypeName": "NeoTokenBudgetWindowKind"
+            }
+          }
+        },
+        "required": [
+          "baseAllowanceTokens",
+          "consumedTokens",
+          "effectiveAllowanceTokens",
+          "exhausted",
+          "windowEnd",
+          "windowKind"
         ],
         "type": "object"
       },
@@ -16582,7 +18923,7 @@
         "description": "OrganizationAuditLogExportSettings is an organization's current audit log export configuration.",
         "properties": {
           "enabled": {
-            "description": "Enabled tracks if we are still trying to deliver audit log events, or if\nit has been paused/disabled (e.g. because of repeated auth issues.)",
+            "description": "Whether audit log export is currently active. May be paused automatically if the configured destination repeatedly fails to authenticate.",
             "type": "boolean",
             "x-order": 1
           },
@@ -16607,280 +18948,401 @@
       "OrganizationFeatures": {
         "description": "OrganizationFeatures represents paid features for organizations.",
         "properties": {
+          "accessTokenExpiryPolicyEnabled": {
+            "description": "Whether the per-org access token expiry policy (admin-configurable maximum lifetime for personal, organization, and team access tokens) is enabled.",
+            "type": "boolean",
+            "x-order": 75
+          },
           "agentIntegrationCatalogEnabled": {
             "description": "Whether the agent integration catalog is enabled.",
             "type": "boolean",
-            "x-order": 52
+            "x-order": 53
           },
           "agentPoolRegistrationEnabled": {
             "description": "Whether agent pool registration is enabled for self-hosted deployments.",
             "type": "boolean",
-            "x-order": 18
+            "x-order": 20
+          },
+          "agentScheduledTasksEnabled": {
+            "description": "Whether agent automations are enabled.",
+            "type": "boolean",
+            "x-order": 54
           },
           "aiAgentsEnabled": {
             "description": "Whether AI agents (Pulumi Copilot) are enabled.",
             "type": "boolean",
-            "x-order": 40
+            "x-order": 43
+          },
+          "aiReviewCodeAccessEnabled": {
+            "description": "Whether AI review code access is enabled.",
+            "type": "boolean",
+            "x-order": 55
           },
           "aleEnabled": {
             "description": "Whether audit log export (ALE) is enabled.",
             "type": "boolean",
-            "x-order": 5
+            "x-order": 6
           },
           "approvalsEnabled": {
             "description": "Whether change request approvals are enabled.",
             "type": "boolean",
-            "x-order": 32
+            "x-order": 35
           },
           "auditLogUIFilteringEnabled": {
             "description": "Whether audit log UI filtering is enabled.",
             "type": "boolean",
-            "x-order": 22
+            "x-order": 24
           },
           "auditLogsEnabled": {
             "description": "Whether audit logs are enabled for the organization.",
             "type": "boolean",
             "x-order": 1
           },
+          "bitbucketVCSEnabled": {
+            "description": "Whether Bitbucket VCS integration is enabled.",
+            "type": "boolean",
+            "x-order": 58
+          },
           "bringYourOwnKeyEnabled": {
             "description": "Whether bring-your-own-key encryption is enabled.",
             "type": "boolean",
-            "x-order": 31
+            "x-order": 34
+          },
+          "cliIntegrationCatalogEnabled": {
+            "description": "Whether the CLI integration catalog is enabled.",
+            "type": "boolean",
+            "x-order": 61
           },
           "crossGuardEnabled": {
             "description": "Whether CrossGuard policy enforcement is enabled.",
             "type": "boolean",
-            "x-order": 2
+            "x-order": 3
           },
           "customRoleCondition": {
             "description": "Whether custom role conditions are enabled.",
             "type": "boolean",
-            "x-order": 44
+            "x-order": 45
           },
           "customRolesEnabled": {
             "description": "Whether custom RBAC roles are enabled.",
             "type": "boolean",
-            "x-order": 26
+            "x-order": 28
           },
           "customTemplatesEnabled": {
             "description": "Whether custom templates are enabled.",
             "type": "boolean",
-            "x-order": 12
+            "x-order": 13
+          },
+          "customVCSEnabled": {
+            "description": "Whether custom VCS integrations are enabled.",
+            "type": "boolean",
+            "x-order": 57
           },
           "dashboardOnboardingUIEnabled": {
             "description": "Whether the dashboard onboarding UI is enabled.",
             "type": "boolean",
-            "x-order": 19
+            "x-order": 21
           },
           "dependencyCachingEnabled": {
             "description": "Whether dependency caching for deployments is enabled.",
             "type": "boolean",
-            "x-order": 23
+            "x-order": 25
           },
           "deployEnabled": {
             "description": "Whether Pulumi Deployments is enabled.",
             "type": "boolean",
-            "x-order": 6
+            "x-order": 7
+          },
+          "deploymentOidcSettingsEnabled": {
+            "description": "Whether the Deployments OIDC settings UI is shown.",
+            "type": "boolean",
+            "x-order": 72
           },
           "discoveredStacksEnabled": {
             "description": "Whether discovered stacks are enabled.",
             "type": "boolean",
-            "x-order": 51
+            "x-order": 52
           },
           "driftDetectionEnabled": {
             "description": "Whether drift detection is enabled.",
             "type": "boolean",
-            "x-order": 20
+            "x-order": 22
+          },
+          "driftRemediationEnabled": {
+            "description": "Whether drift remediation (auto-remediate via pulumi up --refresh) is enabled.",
+            "type": "boolean",
+            "x-order": 64
           },
           "environmentRevisionTagsEnabled": {
             "description": "Whether environment revision tags are enabled.",
             "type": "boolean",
-            "x-order": 15
+            "x-order": 16
           },
           "environmentSecretRotationEnabled": {
             "description": "Whether environment secret rotation is enabled.",
             "type": "boolean",
-            "x-order": 27
+            "x-order": 30
           },
           "environmentsEnabled": {
             "description": "Whether Pulumi ESC environments are enabled.",
             "type": "boolean",
-            "x-order": 14
+            "x-order": 15
           },
           "environmentsRestoreEnabled": {
             "description": "Whether restoring deleted environments is enabled.",
             "type": "boolean",
-            "x-order": 24
+            "x-order": 26
           },
           "escEditorRevampEnabled": {
             "description": "Whether the ESC editor revamp is enabled.",
             "type": "boolean",
-            "x-order": 35
+            "x-order": 38
           },
           "escOnboardingAzureOAuthClientEnabled": {
             "description": "Whether the Azure OAuth client for ESC onboarding is enabled.",
             "type": "boolean",
-            "x-order": 36
+            "x-order": 39
           },
           "escOnboardingEnabled": {
             "description": "Whether ESC onboarding is enabled.",
             "type": "boolean",
-            "x-order": 33
+            "x-order": 36
           },
           "escOnboardingGcpOAuthClientEnabled": {
             "description": "Whether the GCP OAuth client for ESC onboarding is enabled.",
             "type": "boolean",
-            "x-order": 37
+            "x-order": 40
           },
           "escOnboardingV2Enabled": {
             "description": "Whether ESC onboarding v2 is enabled.",
             "type": "boolean",
-            "x-order": 34
+            "x-order": 37
+          },
+          "expandedPolicyEnforcementLevelsEnabled": {
+            "description": "Whether expanded policy enforcement levels (including the Remediate level) are enabled.",
+            "type": "boolean",
+            "x-order": 65
+          },
+          "fixDriftWithNeoEnabled": {
+            "description": "Whether fixing drift with Neo is enabled.",
+            "type": "boolean",
+            "x-order": 60
           },
           "getStartedOnboardEnabled": {
             "description": "Whether the getting started onboarding flow is enabled.",
             "type": "boolean",
-            "x-order": 49
+            "x-order": 50
           },
           "ghAppDetailedDiffEnabled": {
             "description": "Whether the GitHub App detailed diff view is enabled.",
             "type": "boolean",
-            "x-order": 46
+            "x-order": 47
+          },
+          "gitHubEnterpriseIndividualAuthEnabled": {
+            "deprecated": true,
+            "description": "Deprecated. Per-user (individual) GitHub Enterprise authentication is now a per-installation setting; no longer populated.",
+            "type": "boolean",
+            "x-order": 19
           },
           "gitHubEnterpriseIntegrationEnabled": {
             "description": "Whether GitHub Enterprise integration is enabled.",
             "type": "boolean",
-            "x-order": 17
+            "x-order": 18
+          },
+          "hasTerraformModules": {
+            "description": "Whether the organization has any Terraform modules in the registry. Data-driven (not plan-gated): drives the Terraform Modules console nav entry so customers can manage existing modules even on plans without publishing.",
+            "type": "boolean",
+            "x-order": 2
           },
           "iacCloudImportEnabled": {
             "description": "Whether IaC cloud import is enabled.",
             "type": "boolean",
-            "x-order": 30
+            "x-order": 33
+          },
+          "insightsAutoPolicyPacksEnabled": {
+            "description": "Whether the Insights auto policy packs experience (including the bulk account discover wizard) is enabled.",
+            "type": "boolean",
+            "x-order": 59
           },
           "insightsMonetizationEnabled": {
             "description": "Whether Insights monetization features are enabled.",
             "type": "boolean",
-            "x-order": 28
+            "x-order": 31
           },
           "integrationAssistantEnabled": {
             "description": "Whether the integration assistant is enabled.",
             "type": "boolean",
-            "x-order": 4
+            "x-order": 5
           },
           "legacyDeploymentsOrgToken": {
             "description": "Whether the organization uses a legacy org token for deployments.",
             "type": "boolean",
-            "x-order": 16
+            "x-order": 17
+          },
+          "machineTokensEnabled": {
+            "description": "Whether machine tokens (organization access tokens) are enabled.",
+            "type": "boolean",
+            "x-order": 66
+          },
+          "neoCodeReviewsEnabled": {
+            "description": "Whether agentic Neo Code Reviews (a single agentic review per pull request, replacing the legacy per-stack AI preview summaries) are enabled.",
+            "type": "boolean",
+            "x-order": 56
           },
           "neoPlanModeEnabled": {
             "description": "Whether Neo plan mode is enabled.",
             "type": "boolean",
-            "x-order": 48
+            "x-order": 49
           },
           "neoReadOnlyEnabled": {
             "description": "Whether Neo read-only permission mode is enabled.",
             "type": "boolean",
-            "x-order": 50
+            "x-order": 51
           },
           "neoServerSideApprovalsEnabled": {
             "description": "Whether Neo server side approvals is enabled.",
             "type": "boolean",
-            "x-order": 47
-          },
-          "neoSlashCommandsEnabled": {
-            "description": "Whether Copilot slash commands are enabled.",
-            "type": "boolean",
-            "x-order": 43
+            "x-order": 48
           },
           "neoTaskSharingEnabled": {
             "description": "Whether Copilot task sharing is enabled.",
             "type": "boolean",
-            "x-order": 45
+            "x-order": 46
           },
-          "newWizardV2Enabled": {
-            "description": "Whether the new project wizard v2 is enabled.",
+          "neoTokenMeteringEnabled": {
+            "description": "Whether the Neo Token usage page under Billing & usage is enabled.",
             "type": "boolean",
-            "x-order": 41
+            "x-order": 70
+          },
+          "neoUsageLimitsEnabled": {
+            "description": "Whether org-configurable Neo usage limits (monthly dollar caps) are enabled.",
+            "type": "boolean",
+            "x-order": 73
           },
           "nlpSearchEnabled": {
             "description": "Whether natural language search is enabled.",
             "type": "boolean",
-            "x-order": 11
+            "x-order": 12
           },
           "pangeaAccountsScanPageEnabled": {
             "description": "Whether the Pangea accounts scan page is enabled.",
             "type": "boolean",
-            "x-order": 25
+            "x-order": 27
           },
           "policyIssueManagementEnabled": {
             "description": "Whether policy issue management is enabled.",
             "type": "boolean",
-            "x-order": 39
+            "x-order": 42
           },
           "policyManagementV2Enabled": {
             "description": "Whether policy management v2 is enabled.",
             "type": "boolean",
-            "x-order": 38
+            "x-order": 41
           },
           "propertySearchUIEnabled": {
             "description": "Whether the property search UI is enabled.",
             "type": "boolean",
-            "x-order": 10
+            "x-order": 11
           },
           "resourceExportEnabled": {
             "description": "Whether resource export is enabled.",
             "type": "boolean",
-            "x-order": 9
+            "x-order": 10
           },
           "resourceSearchEnabled": {
             "description": "Whether resource search is enabled.",
             "type": "boolean",
-            "x-order": 8
+            "x-order": 9
           },
           "restoreStacksEnabled": {
             "description": "Whether restoring deleted stacks is enabled.",
             "type": "boolean",
-            "x-order": 13
+            "x-order": 14
+          },
+          "samlSsoEnabled": {
+            "description": "Whether SAML SSO configuration is enabled.",
+            "type": "boolean",
+            "x-order": 67
           },
           "scimEnabled": {
             "description": "Whether SCIM provisioning is enabled.",
             "type": "boolean",
-            "x-order": 7
+            "x-order": 8
           },
           "selfHostedDeploymentsEnabled": {
             "description": "Whether self-hosted deployment agents are enabled.",
             "type": "boolean",
-            "x-order": 21
+            "x-order": 23
           },
           "selfServeIDPRemoval": {
             "description": "Whether self-serve IDP removal is enabled.",
             "type": "boolean",
-            "x-order": 29
+            "x-order": 32
+          },
+          "serviceBackedConfigEnabled": {
+            "description": "Whether service-backed stack config is enabled.",
+            "type": "boolean",
+            "x-order": 62
+          },
+          "tagBasedDeploymentTriggersEnabled": {
+            "description": "Whether tag-based deployment triggers are enabled.",
+            "type": "boolean",
+            "x-order": 71
+          },
+          "teamMemberRoleManagementEnabled": {
+            "description": "Whether team member role management (assigning custom roles per team member) is enabled.",
+            "type": "boolean",
+            "x-order": 68
+          },
+          "teamsEnabled": {
+            "description": "Whether team management (creating and assigning teams) is enabled.",
+            "type": "boolean",
+            "x-order": 69
           },
           "themingEnabled": {
             "description": "Whether UI theming is enabled.",
             "type": "boolean",
-            "x-order": 42
+            "x-order": 44
+          },
+          "universalSearchEnabled": {
+            "description": "Whether universal search is enabled.",
+            "type": "boolean",
+            "x-order": 63
+          },
+          "unlinkedGitHubAppRecoveryEnabled": {
+            "description": "Whether recovery for unlinked GitHub App installations (linking an existing installation to the organization) is enabled.",
+            "type": "boolean",
+            "x-order": 74
+          },
+          "usersCustomRolesEnabled": {
+            "description": "Whether assigning custom RBAC roles to individual users is enabled.",
+            "type": "boolean",
+            "x-order": 29
           },
           "webhooksEnabled": {
             "description": "Whether webhooks are enabled for the organization.",
             "type": "boolean",
-            "x-order": 3
+            "x-order": 4
           }
         },
         "required": [
           "agentIntegrationCatalogEnabled",
           "agentPoolRegistrationEnabled",
+          "agentScheduledTasksEnabled",
           "aiAgentsEnabled",
+          "aiReviewCodeAccessEnabled",
           "aleEnabled",
           "approvalsEnabled",
           "auditLogUIFilteringEnabled",
           "auditLogsEnabled",
+          "bitbucketVCSEnabled",
           "bringYourOwnKeyEnabled",
+          "cliIntegrationCatalogEnabled",
           "crossGuardEnabled",
           "customRoleCondition",
           "customRolesEnabled",
           "customTemplatesEnabled",
+          "customVCSEnabled",
           "dashboardOnboardingUIEnabled",
           "dependencyCachingEnabled",
           "deployEnabled",
@@ -16895,19 +19357,19 @@
           "escOnboardingEnabled",
           "escOnboardingGcpOAuthClientEnabled",
           "escOnboardingV2Enabled",
+          "fixDriftWithNeoEnabled",
           "getStartedOnboardEnabled",
           "ghAppDetailedDiffEnabled",
           "gitHubEnterpriseIntegrationEnabled",
           "iacCloudImportEnabled",
+          "insightsAutoPolicyPacksEnabled",
           "insightsMonetizationEnabled",
           "integrationAssistantEnabled",
           "legacyDeploymentsOrgToken",
           "neoPlanModeEnabled",
           "neoReadOnlyEnabled",
           "neoServerSideApprovalsEnabled",
-          "neoSlashCommandsEnabled",
           "neoTaskSharingEnabled",
-          "newWizardV2Enabled",
           "nlpSearchEnabled",
           "pangeaAccountsScanPageEnabled",
           "policyIssueManagementEnabled",
@@ -16919,6 +19381,7 @@
           "scimEnabled",
           "selfHostedDeploymentsEnabled",
           "selfServeIDPRemoval",
+          "serviceBackedConfigEnabled",
           "themingEnabled",
           "webhooksEnabled"
         ],
@@ -16935,7 +19398,7 @@
           },
           "fgaRole": {
             "$ref": "#/components/schemas/FGARole",
-            "description": "FGARole contains the Fine-Grained Access Control role assigned to this member.\nThis is either their specifically assigned role or the organization's default role.",
+            "description": "The role currently assigned to this member — either a built-in role (member, admin, billingManager) or a custom role. Falls back to the organization's default role if no role is assigned directly.",
             "x-order": 7
           },
           "knownToPulumi": {
@@ -16949,7 +19412,8 @@
             "x-order": 6
           },
           "role": {
-            "description": "The member's role within the organization.",
+            "deprecated": true,
+            "description": "**Deprecated:** Use `fgaRole` instead. The member's built-in role within the organization. For members assigned a custom role, this is the closest built-in projection (`member`, `admin`, or `billingManager`) and may lose detail; `fgaRole` is authoritative.",
             "enum": [
               "none",
               "member",
@@ -16981,6 +19445,15 @@
               "enumTypeName": "OrganizationRole"
             }
           },
+          "teams": {
+            "deprecated": true,
+            "description": "Deprecated. Use GetOrganizationMemberTeams to list teams.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "x-order": 8
+          },
           "user": {
             "$ref": "#/components/schemas/UserInfo",
             "description": "The user information for this organization member.",
@@ -17009,17 +19482,17 @@
             "description": "AccountCount is the current number of Insights Accounts in the organization.\n(May be more than the requesting user has permission to see.)",
             "format": "int64",
             "type": "integer",
-            "x-order": 29
+            "x-order": 34
           },
           "aiEnablement": {
             "description": "The AI feature enablement status for the organization (e.g. enabled, disabled, opt-in).",
             "type": "string",
-            "x-order": 24
+            "x-order": 29
           },
           "auditLogsEnabled": {
             "description": "Deprecated. Access the AuditLogsEnabled feature from the Features property.",
             "type": "boolean",
-            "x-order": 26
+            "x-order": 31
           },
           "backingOrgLogin": {
             "description": "The login name of the backing organization on the identity provider.",
@@ -17042,7 +19515,7 @@
             ],
             "format": "int64",
             "type": "integer",
-            "x-order": 12,
+            "x-order": 14,
             "x-pulumi-model-property": {
               "enumComments": "InsightsAccountPermission is a value describing the permission level a user has for a Pulumi Insights account.",
               "enumFieldComments": [
@@ -17060,6 +19533,11 @@
               "enumTypeName": "InsightsAccountPermission"
             }
           },
+          "defaultDeploymentRoleId": {
+            "description": "DefaultDeploymentRoleID is the ID of the default role used for deployments when no specific role is configured in the stack's deployment settings. If unset, deployments run using the triggering user's own permissions.",
+            "type": "string",
+            "x-order": 42
+          },
           "defaultEnvironmentPermission": {
             "description": "DefaultEnvironmentPermission is the default permission every member\nhas for accessing the organization's environments.",
             "enum": [
@@ -17070,7 +19548,7 @@
               "admin"
             ],
             "type": "string",
-            "x-order": 11,
+            "x-order": 13,
             "x-pulumi-model-property": {
               "enumComments": "EnvironmentPermission is an enum describing the permission level to access an environment.",
               "enumTypeName": "EnvironmentPermission"
@@ -17079,7 +19557,7 @@
           "defaultRoleId": {
             "description": "DefaultRoleID is the ID of the default role for new users added to the organization.\nIf unset, defaults to the \"Member\" role.",
             "type": "string",
-            "x-order": 36
+            "x-order": 41
           },
           "defaultStackPermission": {
             "description": "DefaultStackPermission is the default permission every member\nhas for accessing the organization's stacks.",
@@ -17092,7 +19570,7 @@
             ],
             "format": "int64",
             "type": "integer",
-            "x-order": 10,
+            "x-order": 12,
             "x-pulumi-model-property": {
               "enumComments": "StackPermission is a value describing the permission level a user has for a Pulumi stack.\nLike OrganizationRole, there is a total ordering of StackPermission values, where each value\ngrants an additional layer of permissions. IMPORTANT: Do not rely on the numeric values for\nauth checks, instead, just refer to these as opaque names. e.g. use explicit matching in a\ncase-statements instead of \"if perm >= StackPermissionX\". This prevents errors if we later\nadd a new StackPermission \"in between\" two existing ones, but with a new, higher value.\nPreviously, the StackPermission value was a series of bit flags, with each bit controlling\na specific operation on the stack. However, that proved difficult to describe and maintain.\nSo the newer, \"fixed set\" approach is used instead.\nThe conversion from the legacy permission values and the new StackPermission values is done\ntransparently, whenever data is read/written to the database. (Converting to the newer\nvalues as needed.) We will only be able to remove these legacy values after we deploy the\ncode which can read both formats, and only writes the newer format.",
               "enumFieldComments": [
@@ -17116,12 +19594,12 @@
             "description": "EnvironmentCount is the current number of environments in the organization.\n(May be more than the requesting user has permission to see.)",
             "format": "int64",
             "type": "integer",
-            "x-order": 30
+            "x-order": 35
           },
           "features": {
             "$ref": "#/components/schemas/OrganizationFeatures",
             "description": "The feature flags enabled for this organization, controlling access to specific functionality.",
-            "x-order": 28
+            "x-order": 33
           },
           "id": {
             "description": "The unique identifier of the organization.",
@@ -17131,18 +19609,18 @@
           "insightsBillingAccepted": {
             "description": "true if accepted, false if denied, nil if no action taken",
             "type": "boolean",
-            "x-order": 22
+            "x-order": 27
           },
           "insightsTrialEnd": {
             "description": "The Unix timestamp when the Insights trial ends.",
             "format": "int64",
             "type": "integer",
-            "x-order": 21
+            "x-order": 26
           },
           "insightsTrialUsingPolicy": {
             "description": "true if org needs to be upgraded to business critical",
             "type": "boolean",
-            "x-order": 23
+            "x-order": 28
           },
           "kind": {
             "description": "The kind of backing identity provider for the organization.",
@@ -17187,7 +19665,7 @@
               "transfer-in-progress"
             ],
             "type": "string",
-            "x-order": 35,
+            "x-order": 40,
             "x-pulumi-model-property": {
               "enumComments": "OrganizationLockedStatus describes why an organization may be locked or restricted.",
               "enumFieldNames": [
@@ -17200,48 +19678,64 @@
               "enumTypeName": "OrganizationLockedStatus"
             }
           },
+          "maxAccessTokenExpiryDays": {
+            "description": "The maximum allowed access token expiry, in days, for personal, organization, and team access tokens used against this organization. Null means no policy (the default behavior, in which tokens may have any expiry or no expiry). When set, requires every token to have an expiry, and the remaining lifetime of the token must not exceed this many days. Web sessions and system-managed tokens are not subject to this policy.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 43
+          },
           "maxMembers": {
             "description": "MaxMembers is the maximum number of members the organization can have\nbased on its subscription. (Only set for per-member billed orgs.)",
             "format": "int64",
             "type": "integer",
-            "x-order": 34
+            "x-order": 39
           },
           "maxStacks": {
             "description": "MaxStacks is the maximum number of stacks the organization can have\nbased on its subscription. Will be nil/omitted if there is no limit.",
             "format": "int64",
             "type": "integer",
-            "x-order": 32
+            "x-order": 37
           },
           "memberCount": {
             "description": "MemberCount is the number of members the organization has. Will be\nincorrect for organizations on the TeamPerStack subscription plan.",
             "format": "int64",
             "type": "integer",
-            "x-order": 33
+            "x-order": 38
           },
           "membersCanCreateAccounts": {
             "description": "Whether organization members can create Insights accounts.",
             "type": "boolean",
-            "x-order": 17
+            "x-order": 19
           },
           "membersCanCreateStacks": {
             "description": "Whether organization members can create stacks.",
             "type": "boolean",
-            "x-order": 13
+            "x-order": 15
           },
           "membersCanCreateTeams": {
             "description": "Whether organization members can create teams.",
             "type": "boolean",
-            "x-order": 16
+            "x-order": 18
           },
           "membersCanDeleteStacks": {
             "description": "Whether organization members can delete stacks.",
             "type": "boolean",
-            "x-order": 14
+            "x-order": 16
           },
           "membersCanTransferStacks": {
             "description": "Whether organization members can transfer stacks.",
             "type": "boolean",
-            "x-order": 15
+            "x-order": 17
+          },
+          "naturalLanguageSearchDisabled": {
+            "description": "Whether natural-language resource search is disabled for the organization. Independent of neoEnabled; if neoEnabled is false, this flag has no additional effect.",
+            "type": "boolean",
+            "x-order": 24
+          },
+          "neoAgentDisabled": {
+            "description": "Whether the Neo agent is disabled for the organization. Independent of neoEnabled; if neoEnabled is false, this flag has no additional effect.",
+            "type": "boolean",
+            "x-order": 25
           },
           "neoApprovalMode": {
             "description": "neoApprovalMode is the default approval mode for new Neo AI agent tasks.",
@@ -17251,16 +19745,21 @@
               "balanced"
             ],
             "type": "string",
-            "x-order": 19,
+            "x-order": 21,
             "x-pulumi-model-property": {
               "enumComments": "NeoApprovalMode represents the default approval mode for Neo AI agent tasks in an organization",
               "enumTypeName": "NeoApprovalMode"
             }
           },
+          "neoCLIExplanationsDisabled": {
+            "description": "Whether Neo CLI explanations (preview and update-failure explanations served to the CLI) are disabled for the organization. Independent of neoEnabled; if neoEnabled is false, this flag has no additional effect.",
+            "type": "boolean",
+            "x-order": 23
+          },
           "neoEnabled": {
             "description": "Whether Neo AI agent features are enabled for the organization.",
             "type": "boolean",
-            "x-order": 18
+            "x-order": 20
           },
           "neoTaskSharingMode": {
             "description": "NeoTaskSharingMode is the task sharing mode for Neo AI agents in the organization.",
@@ -17269,7 +19768,7 @@
               "org"
             ],
             "type": "string",
-            "x-order": 20,
+            "x-order": 22,
             "x-pulumi-model-property": {
               "enumComments": "NeoTaskSharingMode represents the task sharing mode for Neo AI agents in an organization",
               "enumTypeName": "NeoTaskSharingMode"
@@ -17284,7 +19783,7 @@
               "gitlab"
             ],
             "type": "string",
-            "x-order": 25,
+            "x-order": 30,
             "x-pulumi-model-property": {
               "enumComments": "PreferredVCS represents an organization selected preferred VCS vendor",
               "enumFieldNames": [
@@ -17338,16 +19837,28 @@
               "enumTypeName": "SaasOffer"
             }
           },
+          "retrialExpiration": {
+            "description": "The time when the organization's active retrial expires, if it is on a retrial.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 8
+          },
           "stackCount": {
             "description": "StackCount is the current number of stacks in the organization.\n(May be more than the requesting user has permission to see.)",
             "format": "int64",
             "type": "integer",
-            "x-order": 31
+            "x-order": 36
           },
           "subscriptionCancelAtPeriodEnd": {
             "description": "Whether the subscription will be canceled at the end of the current billing period.",
             "type": "boolean",
-            "x-order": 8
+            "x-order": 9
+          },
+          "subscriptionPeriodEnd": {
+            "description": "The time when the current subscription or license period ends. For SaaS subscriptions this is the Stripe billing period end. For self-hosted installations this is the license expiry date.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 10
           },
           "subscriptionStatus": {
             "description": "The Stripe subscription status (e.g. active, past_due, canceled), if applicable.",
@@ -17371,7 +19882,7 @@
               "billing-manager"
             ],
             "type": "string",
-            "x-order": 9,
+            "x-order": 11,
             "x-pulumi-model-property": {
               "enumComments": "OrganizationRole is an enum defining a member's role within an organization.",
               "enumFieldComments": [
@@ -17396,7 +19907,7 @@
           "webhooksEnabled": {
             "description": "Deprecated. Access the WebhooksEnabled feature from the Features property.",
             "type": "boolean",
-            "x-order": 27
+            "x-order": 32
           }
         },
         "required": [
@@ -17418,7 +19929,10 @@
           "membersCanCreateTeams",
           "membersCanDeleteStacks",
           "membersCanTransferStacks",
+          "naturalLanguageSearchDisabled",
+          "neoAgentDisabled",
           "neoApprovalMode",
+          "neoCLIExplanationsDisabled",
           "neoEnabled",
           "neoTaskSharingMode",
           "preferredVCS",
@@ -17501,6 +20015,9 @@
                 }
               }
             },
+            "required": [
+              "role"
+            ],
             "type": "object"
           }
         ]
@@ -17771,24 +20288,28 @@
         },
         "type": "object"
       },
-      "PatchConversationRequest": {
-        "description": "Request body for partially updating a conversation.",
+      "PageContext": {
+        "description": "Describes the Pulumi Cloud page the user has the Neo pane open on. Sent on every Neo prompt request (initial creation and follow-ups) so the agent's system prompt can reference the user's current location. The schema is intentionally generic: `path` is the raw URL, `params` carries route path parameters extracted by the client, and `kind` is an optional stable label set by the route definition (in console2 via `data: { pageContextKind: ... }`) for cases where the agent should special-case the page. New pages flow through automatically — only routes that need stable agent treatment must declare a `kind`.",
         "properties": {
-          "summary": {
-            "description": "The updated summary of the conversation.",
-            "type": "string",
-            "x-order": 2
-          },
-          "title": {
-            "description": "The updated title of the conversation.",
+          "kind": {
+            "description": "Optional stable label declared by the route, used by the agent to phrase the user's location in its system prompt or branch on well-known pages. Examples: 'stack-update', 'environment', 'neo-task'. Routes without a declared kind leave this null; the agent falls back to the path and params.",
             "type": "string",
             "x-order": 1
+          },
+          "params": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Route path parameters extracted from the matched Angular route, keyed by parameter name (e.g. {'organization': 'myorg', 'project': 'myapp', 'stack': 'prod', 'version': '47'}). Empty for routes with no path parameters.",
+            "type": "object",
+            "x-order": 3
+          },
+          "path": {
+            "description": "Raw URL path of the page the user is viewing (e.g. '/myorg/myapp/prod/updates/47'). Always populated.",
+            "type": "string",
+            "x-order": 2
           }
         },
-        "required": [
-          "summary",
-          "title"
-        ],
         "type": "object"
       },
       "PatchEnvironmentSettingsRequest": {
@@ -18641,7 +21162,7 @@
             "type": "string",
             "x-order": 4,
             "x-pulumi-model-property": {
-              "enumComments": "Categorizes how a permission descriptor is presented in the UI. Valid values: role, role_private, policy, set.",
+              "enumComments": "Categorizes how a permission descriptor is presented in the UI.",
               "enumFieldNames": [
                 "Role",
                 "RolePrivate",
@@ -18784,7 +21305,7 @@
                 "x-order": 2
               },
               "orgId": {
-                "description": "The ID of theorganization this role belongs to.",
+                "description": "The ID of the organization this role belongs to.",
                 "type": "string",
                 "x-order": 4
               },
@@ -18795,6 +21316,14 @@
                 "x-order": 6
               }
             },
+            "required": [
+              "created",
+              "id",
+              "isOrgDefault",
+              "modified",
+              "orgId",
+              "version"
+            ],
             "type": "object"
           }
         ]
@@ -20107,7 +22636,7 @@
             "x-order": 1
           },
           "vcsKind": {
-            "description": "BUG: This should actually be the OrganizationKind enum, as otherwise we couldn't properly\ndifferentiate the \"single user organization\" case.",
+            "description": "The identity provider associated with this GitHub organization.",
             "enum": [
               "dev.azure.com",
               "bitbucket.org",
@@ -20280,7 +22809,7 @@
             "x-order": 2
           },
           "programId": {
-            "description": "We are using the program ID exposed as ID. This is done this way\nbecause the program ID is widely used internally to identify the stack\nand because of the database schema, there is no cheap way to get the program\nfrom the stack ID without introducing new indexes (and due how central and large\nthese tables are, we don't want to add new indexes lightly).",
+            "description": "Unique identifier for the stack.",
             "type": "string",
             "x-order": 1
           },
@@ -21020,6 +23549,7 @@
               "Roles",
               "Search",
               "Copilot",
+              "Neo",
               "Organization annotations",
               "OIDC",
               "Templates",
@@ -21061,6 +23591,7 @@
                 "Roles",
                 "Search",
                 "Copilot",
+                "Neo",
                 "Annotations",
                 "Oidc",
                 "Templates",
@@ -21110,6 +23641,253 @@
             "type": "object"
           }
         ]
+      },
+      "RegistryContentNode": {
+        "description": "A content node. Clients render 'markdown' for any 'kind' they do not recognize.",
+        "properties": {
+          "kind": {
+            "description": "Node kind. Known kinds: 'text', 'language-chooser', 'os-chooser'. Render 'markdown' for unrecognized kinds.",
+            "type": "string",
+            "x-order": 1
+          },
+          "markdown": {
+            "description": "Markdown content. For 'text' nodes, the content itself. For chooser nodes, a concatenation of options for fallback rendering.",
+            "type": "string",
+            "x-order": 2
+          },
+          "options": {
+            "description": "Options for chooser nodes; absent for 'text'.",
+            "items": {
+              "$ref": "#/components/schemas/RegistryContentNodeOption"
+            },
+            "type": "array",
+            "x-order": 3
+          }
+        },
+        "required": [
+          "kind",
+          "markdown"
+        ],
+        "type": "object"
+      },
+      "RegistryContentNodeOption": {
+        "description": "A single option within a chooser content node, representing one language or OS variant.",
+        "properties": {
+          "content": {
+            "description": "The content for this option, typically a code snippet or instructions.",
+            "type": "string",
+            "x-order": 3
+          },
+          "language": {
+            "description": "The language this option applies to (for 'language-chooser' nodes). One of: typescript, python, go, csharp, java, yaml.",
+            "type": "string",
+            "x-order": 1
+          },
+          "os": {
+            "description": "The operating system this option applies to (for 'os-chooser' nodes). One of: linux, macos, windows.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "RegistryDocsEnumValue": {
+        "description": "A value in an enum type definition.",
+        "properties": {
+          "description": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Description keyed by language.",
+            "type": "object",
+            "x-order": 3
+          },
+          "name": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Enum value name keyed by language.",
+            "type": "object",
+            "x-order": 1
+          },
+          "value": {
+            "description": "Wire value of this enum variant.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "type": "object"
+      },
+      "RegistryDocsProperty": {
+        "description": "A property of a resource or function.",
+        "properties": {
+          "deprecated": {
+            "description": "Whether this property is deprecated.",
+            "type": "boolean",
+            "x-order": 5
+          },
+          "description": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Markdown description, keyed by language.",
+            "type": "object",
+            "x-order": 6
+          },
+          "name": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Property name, keyed by language.",
+            "type": "object",
+            "x-order": 1
+          },
+          "replaceOnChanges": {
+            "description": "Whether changing this property forces replacement.",
+            "type": "boolean",
+            "x-order": 4
+          },
+          "required": {
+            "description": "Whether the property is required.",
+            "type": "boolean",
+            "x-order": 3
+          },
+          "type": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Display type, keyed by language.",
+            "type": "object",
+            "x-order": 2
+          },
+          "typeRef": {
+            "$ref": "#/components/schemas/RegistryDocsTypeRef",
+            "description": "Reference to a local supporting type or a remote type. Null for primitive types.",
+            "x-order": 7
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "replaceOnChanges",
+          "required",
+          "type"
+        ],
+        "type": "object"
+      },
+      "RegistryDocsSupportingType": {
+        "description": "A supporting type (object or enum) referenced by properties. Inlined, not referenced by index.",
+        "properties": {
+          "kind": {
+            "description": "'object' or 'enum'.",
+            "type": "string",
+            "x-order": 3
+          },
+          "name": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Display name keyed by language.",
+            "type": "object",
+            "x-order": 2
+          },
+          "properties": {
+            "description": "Properties (when kind is 'object').",
+            "items": {
+              "$ref": "#/components/schemas/RegistryDocsProperty"
+            },
+            "type": "array",
+            "x-order": 4
+          },
+          "typeToken": {
+            "description": "Pulumi type token of this type.",
+            "type": "string",
+            "x-order": 1
+          },
+          "values": {
+            "description": "Enum values (when kind is 'enum').",
+            "items": {
+              "$ref": "#/components/schemas/RegistryDocsEnumValue"
+            },
+            "type": "array",
+            "x-order": 5
+          }
+        },
+        "required": [
+          "kind",
+          "name",
+          "typeToken"
+        ],
+        "type": "object"
+      },
+      "RegistryDocsTypeRef": {
+        "description": "A reference to a type, either local (within the same package) or remote (in another package). For local types the type token matches a supportingTypes entry. For remote types, package and version identify the external package.",
+        "properties": {
+          "package": {
+            "description": "The package identifier for remote types (e.g. 'pulumi/pulumi/aws'). Absent for local types within the same package.",
+            "type": "string",
+            "x-order": 2
+          },
+          "typeToken": {
+            "description": "The Pulumi type token of the referenced type.",
+            "type": "string",
+            "x-order": 1
+          },
+          "version": {
+            "description": "The version of the remote package. Absent for local types.",
+            "type": "string",
+            "x-order": 3
+          }
+        },
+        "required": [
+          "typeToken"
+        ],
+        "type": "object"
+      },
+      "RegistryExample": {
+        "description": "A code example extracted from a resource or function description.",
+        "properties": {
+          "code": {
+            "description": "Example source code in the resolved language.",
+            "type": "string",
+            "x-order": 3
+          },
+          "id": {
+            "description": "Stable identifier within the package version. Format: '<typeToken>#<slug>', where slug is the kebab-case title (e.g. 'aws:ec2/instance:Instance#account-analyzer'), falling back to 'example-<short-hash>' when there is no heading. Duplicates within the same type token are suffixed '-2', '-3', etc.",
+            "type": "string",
+            "x-order": 1
+          },
+          "kind": {
+            "description": "Whether 'typeToken' is a 'resource' or 'function'.",
+            "type": "string",
+            "x-order": 5
+          },
+          "title": {
+            "description": "Title derived from the surrounding heading or caption. Capped at 120 chars. Empty when none was available; rely on 'id' for addressability.",
+            "type": "string",
+            "x-order": 2
+          },
+          "typeToken": {
+            "description": "Pulumi type token this example belongs to.",
+            "type": "string",
+            "x-order": 4
+          }
+        },
+        "required": [
+          "code",
+          "id",
+          "kind",
+          "title",
+          "typeToken"
+        ],
+        "type": "object"
       },
       "RegistryPolicyPack": {
         "description": "RegistryPolicyPack represents the core metadata for a policy pack in the registry.\nThis is the primary data structure returned by most registry API endpoints.",
@@ -21205,6 +23983,20 @@
         ],
         "type": "object"
       },
+      "RemoveCustomVCSRepositoryRequest": {
+        "description": "Request to remove a repository from a custom VCS integration. The repository is identified by its name.",
+        "properties": {
+          "name": {
+            "description": "Repository name to remove (must match a previously added name exactly)",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
       "RemoveEnvironmentIdentifier": {
         "description": "Identifier used when removing an environment from a team.",
         "properties": {
@@ -21243,6 +24035,17 @@
           "projectName",
           "stackName"
         ],
+        "type": "object"
+      },
+      "ResendOrganizationInviteRequest": {
+        "description": "ResendOrganizationInviteRequest is for re-sending out invites to join a Pulumi organization.",
+        "properties": {
+          "token": {
+            "description": "Turnstile token",
+            "type": "string",
+            "x-order": 1
+          }
+        },
         "type": "object"
       },
       "Resource": {
@@ -21397,6 +24200,14 @@
             "type": "integer",
             "x-order": 6
           },
+          "tags": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Tag key/value pairs for this usage breakdown entry. Only present when a tag breakdown is requested. Keys correspond to the tagKeys field in the response.",
+            "type": "object",
+            "x-order": 8
+          },
           "weekNumber": {
             "description": "The week number in the year with Sunday marking the start of the week. Ranges from 0-53.",
             "format": "int64",
@@ -21449,6 +24260,47 @@
         "required": [
           "resource"
         ],
+        "type": "object"
+      },
+      "ResourceMigrationAnnotation": {
+        "description": "A user-created migration annotation on a discovered resource.",
+        "properties": {
+          "linkedResourceUrn": {
+            "description": "URN of the resource this one was migrated as part of.",
+            "type": "string",
+            "x-order": 3
+          },
+          "note": {
+            "description": "Free-text note about this resource's migration status. May be empty when only a status override is set.",
+            "type": "string",
+            "x-order": 1
+          },
+          "statusOverride": {
+            "description": "User override of the computed migration status. Only Migrated and NotApplicable are valid overrides.",
+            "enum": [
+              "Migrated",
+              "PulumiOnly",
+              "Ready",
+              "Pending",
+              "Unmapped",
+              "NotApplicable"
+            ],
+            "type": "string",
+            "x-order": 2,
+            "x-pulumi-model-property": {
+              "enumComments": "Migration status of a discovered resource relative to a comparison Pulumi stack. Migrated and PulumiOnly are only possible when the compareTo parameter is provided.",
+              "enumFieldComments": [
+                "Resource identity match found in the comparison stack.",
+                "Resource exists only in the comparison Pulumi stack.",
+                "Mapped to a Pulumi type with virtual state available.",
+                "Mapped to a Pulumi type but no virtual state yet.",
+                "No Pulumi type mapping exists for this resource.",
+                "Migration status is not applicable (e.g. stack or deployment containers)."
+              ],
+              "enumTypeName": "MigrationStatus"
+            }
+          }
+        },
         "type": "object"
       },
       "ResourceResult": {
@@ -21985,7 +24837,8 @@
             "enum": [
               "deployment",
               "environment_rotation",
-              "scan"
+              "scan",
+              "agent_automation"
             ],
             "type": "string",
             "x-order": 7,
@@ -21994,12 +24847,14 @@
               "enumFieldComments": [
                 "A scheduled deployment action.",
                 "A scheduled environment secret rotation action.",
-                "A scheduled Insights scan action."
+                "A scheduled Insights scan action.",
+                "An agent automation."
               ],
               "enumFieldNames": [
                 "Deployment",
                 "EnvironmentRotation",
-                "Scan"
+                "Scan",
+                "AgentAutomation"
               ],
               "enumTypeName": "ScheduledActionKind"
             }
@@ -22254,32 +25109,30 @@
         "type": "object"
       },
       "SecretValue": {
-        "description": "A SecretValue describes a possibly-secret value.\nA value with Secret set to true may be represented as plaintext or ciphertext. A value with Secret set to false\nmay only contain plaintext.",
+        "description": "A SecretValue describes a secret value on the wire. The JSON representation is an object with a required 'secret' field containing the plaintext and an optional 'ciphertext' field containing the encrypted representation.",
         "properties": {
-          "Ciphertext": {
-            "description": "ciphertext",
+          "ciphertext": {
+            "description": "The encrypted representation of the secret value.",
             "items": {
               "format": "byte",
               "type": "string"
             },
             "type": "array",
-            "x-order": 2
-          },
-          "Secret": {
-            "description": "If true, the value is treated as a secret and may be stored as ciphertext. If false, the value is plaintext only.",
-            "type": "boolean",
             "x-order": 3
           },
-          "Value": {
-            "description": "plaintext",
+          "plaintext": {
+            "description": "Not a sensitive value, just plaintext.",
             "type": "string",
             "x-order": 1
+          },
+          "secret": {
+            "description": "The secret value in plaintext.",
+            "type": "string",
+            "x-order": 2
           }
         },
         "required": [
-          "Ciphertext",
-          "Secret",
-          "Value"
+          "secret"
         ],
         "type": "object"
       },
@@ -22514,10 +25367,15 @@
             "description": "Git-based source context for obtaining source code from a repository.",
             "x-order": 1
           },
+          "hg": {
+            "$ref": "#/components/schemas/SourceContextHg",
+            "description": "Mercurial-based source context for obtaining source code from a repository.",
+            "x-order": 2
+          },
           "template": {
             "$ref": "#/components/schemas/SourceContextTemplate",
             "description": "Template-based source context for obtaining source code from a template URL.",
-            "x-order": 2
+            "x-order": 3
           }
         },
         "type": "object"
@@ -22538,7 +25396,7 @@
           "gitAuth": {
             "$ref": "#/components/schemas/GitAuthConfig",
             "description": "(optional) GitAuth allows configuring git authentication options\nThere are 3 different authentication options:\n  * SSH private key (and its optional password)\n  * Personal access token\n  * Basic auth username and password\nOnly one authentication mode will be considered if more than one option is specified,\nwith ssh private key/password preferred first, then personal access token, and finally\nbasic auth credentials.",
-            "x-order": 5
+            "x-order": 6
           },
           "repoDir": {
             "description": "(optional) RepoDir is the directory to work from in the project's source repository\nwhere Pulumi.yaml is located. It is used in case Pulumi.yaml is not\nin the project source root.",
@@ -22549,6 +25407,11 @@
             "description": "The URL of the git repository.",
             "type": "string",
             "x-order": 1
+          },
+          "tag": {
+            "description": "(optional) Tag is the git tag name that triggered this deployment. Set by the service when a deployment is queued by a tag push (e.g. `v1.2.3`). Mutually exclusive with `branch`. When set, `commit` will also be set to the SHA the tag points at.",
+            "type": "string",
+            "x-order": 5
           }
         },
         "type": "object"
@@ -22557,19 +25420,19 @@
         "description": "Request to configure a git-based source context.",
         "properties": {
           "branch": {
-            "description": "The branch to use from the repository.",
+            "description": "The branch to use from the repository. Mutually exclusive with `commit`.",
             "type": "string",
             "x-order": 2
           },
           "commit": {
-            "description": "The commit hash to deploy.",
+            "description": "The commit hash to deploy. Mutually exclusive with `branch`.",
             "type": "string",
             "x-order": 4
           },
           "gitAuth": {
             "$ref": "#/components/schemas/GitAuthConfigRequest",
             "description": "Git authentication configuration.",
-            "x-order": 5
+            "x-order": 6
           },
           "repoDir": {
             "description": "The subdirectory within the repository where Pulumi.yaml is located.",
@@ -22580,22 +25443,94 @@
             "description": "The URL of the git repository.",
             "type": "string",
             "x-order": 1
+          },
+          "tag": {
+            "description": "The git tag that triggered this deployment. Set by the service when a deployment is queued by a tag push. Mutually exclusive with `branch`.",
+            "type": "string",
+            "x-order": 5
+          }
+        },
+        "type": "object"
+      },
+      "SourceContextHg": {
+        "description": "Mercurial-based source context for obtaining source code from a repository.",
+        "properties": {
+          "branch": {
+            "description": "The branch to use from the repository.",
+            "type": "string",
+            "x-order": 2
+          },
+          "hgAuth": {
+            "$ref": "#/components/schemas/GitAuthConfig",
+            "description": "(optional) HgAuth allows configuring Mercurial authentication options.\nThere are 3 different authentication options:\n  * SSH private key (and its optional password)\n  * Personal access token\n  * Basic auth username and password\nOnly one authentication mode will be considered if more than one option is specified,\nwith ssh private key/password preferred first, then personal access token, and finally\nbasic auth credentials.",
+            "x-order": 5
+          },
+          "repoDir": {
+            "description": "(optional) RepoDir is the directory to work from in the project's source repository\nwhere Pulumi.yaml is located. It is used in case Pulumi.yaml is not\nin the project source root.",
+            "type": "string",
+            "x-order": 3
+          },
+          "repoUrl": {
+            "description": "The URL of the Mercurial repository.",
+            "type": "string",
+            "x-order": 1
+          },
+          "revision": {
+            "description": "(optional) Revision is the changeset hash to check out. If used, the working directory\nwill be updated to this specific revision. This is mutually exclusive with the Branch setting.\nEither value needs to be specified.",
+            "type": "string",
+            "x-order": 4
+          }
+        },
+        "type": "object"
+      },
+      "SourceContextHgRequest": {
+        "description": "Request to configure a Mercurial-based source context.",
+        "properties": {
+          "branch": {
+            "description": "The branch to use from the repository.",
+            "type": "string",
+            "x-order": 2
+          },
+          "hgAuth": {
+            "$ref": "#/components/schemas/GitAuthConfigRequest",
+            "description": "Mercurial authentication configuration.",
+            "x-order": 5
+          },
+          "repoDir": {
+            "description": "The subdirectory within the repository where Pulumi.yaml is located.",
+            "type": "string",
+            "x-order": 3
+          },
+          "repoUrl": {
+            "description": "The URL of the Mercurial repository.",
+            "type": "string",
+            "x-order": 1
+          },
+          "revision": {
+            "description": "The changeset hash to check out.",
+            "type": "string",
+            "x-order": 4
           }
         },
         "type": "object"
       },
       "SourceContextRequest": {
-        "description": "Request to configure a source context, either git-based or template-based.",
+        "description": "Request to configure a source context: git-based, Mercurial-based, or template-based. Only one may be specified.",
         "properties": {
           "git": {
             "$ref": "#/components/schemas/SourceContextGitRequest",
             "description": "Git-based source context configuration.",
             "x-order": 1
           },
+          "hg": {
+            "$ref": "#/components/schemas/SourceContextHgRequest",
+            "description": "Mercurial-based source context configuration.",
+            "x-order": 2
+          },
           "template": {
             "$ref": "#/components/schemas/SourceContextTemplateRequest",
             "description": "Template-based source context configuration.",
-            "x-order": 2
+            "x-order": 3
           }
         },
         "type": "object"
@@ -22609,7 +25544,7 @@
             "x-order": 2
           },
           "sourceUrl": {
-            "description": "SourceURL is the URL of the template source.",
+            "description": "The URL of the template source. Supports two URL schemes:\n\n**Registry-backed templates** use the `registry://` scheme with the format:\n`registry://templates/source/publisher/name[@version]`\n\n- `source`: The template source identifier (e.g., the registry source name)\n- `publisher`: The organization or user that published the template\n- `name`: The template name\n- `version`: Optional semver version (e.g., `1.0.0`). If omitted, defaults to the latest version\n\nExample: `registry://templates/pulumi/acme-corp/aws-vpc@2.1.0`\n\n**VCS-backed templates** use standard VCS URLs (GitHub, GitLab, Azure DevOps, etc.):\n`https://github.com/org/repo`",
             "type": "string",
             "x-order": 1
           }
@@ -22625,7 +25560,7 @@
             "x-order": 2
           },
           "sourceUrl": {
-            "description": "The URL of the template source.",
+            "description": "The URL of the template source. Supports two URL schemes:\n\n**Registry-backed templates** use the `registry://` scheme with the format:\n`registry://templates/source/publisher/name[@version]`\n\n- `source`: The template source identifier (e.g., the registry source name)\n- `publisher`: The organization or user that published the template\n- `name`: The template name\n- `version`: Optional semver version (e.g., `1.0.0`). If omitted, defaults to the latest version\n\nExample: `registry://templates/pulumi/acme-corp/aws-vpc@2.1.0`\n\n**VCS-backed templates** use standard VCS URLs (GitHub, GitLab, Azure DevOps, etc.):\n`https://github.com/org/repo`",
             "type": "string",
             "x-order": 1
           }
@@ -22701,12 +25636,17 @@
           "notificationSettings": {
             "$ref": "#/components/schemas/StackNotificationSettings",
             "description": "The notification settings for this stack.",
-            "x-order": 4
+            "x-order": 5
           },
           "orgName": {
             "description": "The organization that owns the stack.",
             "type": "string",
             "x-order": 1
+          },
+          "ownedBy": {
+            "$ref": "#/components/schemas/UserInfo",
+            "description": "The user with ownership of this stack",
+            "x-order": 4
           },
           "projectName": {
             "description": "The project that contains the stack.",
@@ -22722,6 +25662,7 @@
         "required": [
           "notificationSettings",
           "orgName",
+          "ownedBy",
           "projectName",
           "stackName"
         ],
@@ -23165,6 +26106,10 @@
                 "x-order": 1
               }
             },
+            "required": [
+              "name",
+              "project"
+            ],
             "type": "object"
           }
         ]
@@ -23336,9 +26281,8 @@
             "x-order": 2
           },
           "maxOpenDuration": {
-            "description": "The maximum duration (in nanoseconds) an environment session can remain open.",
-            "format": "int64",
-            "type": "integer",
+            "description": "The maximum duration an environment session can remain open, as a Go duration string (e.g. \"1h30m\").",
+            "type": "string",
             "x-order": 4
           },
           "permission": {
@@ -23677,7 +26621,7 @@
         "properties": {
           "destination": {
             "$ref": "#/components/schemas/TemplateDestination",
-            "description": "deprecated - use DestinationURL instead",
+            "description": "Deprecated - use destinationURL instead.",
             "x-order": 7
           },
           "destinationURL": {
@@ -23686,7 +26630,7 @@
             "x-order": 6
           },
           "error": {
-            "description": "An error message if the template source is invalid.",
+            "description": "An error message if the template source is invalid. Omitted or empty when the source is valid.",
             "type": "string",
             "x-order": 3
           },
@@ -23712,8 +26656,6 @@
           }
         },
         "required": [
-          "destination",
-          "error",
           "id",
           "isValid",
           "name",
@@ -23750,6 +26692,303 @@
               }
             },
             "required": [
+              "version"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TerraformModule": {
+        "description": "TerraformModule describes a Terraform module hosted in the Pulumi Cloud registry.",
+        "properties": {
+          "description": {
+            "description": "A free-form text description of the module's purpose.",
+            "type": "string",
+            "x-order": 5
+          },
+          "latestVersion": {
+            "description": "The latest published semantic version of the module.",
+            "type": "string",
+            "x-order": 6
+          },
+          "name": {
+            "description": "The module name.",
+            "type": "string",
+            "x-order": 1
+          },
+          "publisher": {
+            "description": "The organization or user that published the module (the Terraform namespace).",
+            "type": "string",
+            "x-order": 2
+          },
+          "source": {
+            "description": "The source identifier indicating where the module originates from (e.g. 'private').",
+            "type": "string",
+            "x-order": 3
+          },
+          "system": {
+            "description": "The Terraform provider system the module targets (e.g. 'aws', 'azurerm', 'google').",
+            "type": "string",
+            "x-order": 4
+          },
+          "updatedAt": {
+            "description": "The timestamp when the module was last updated.",
+            "format": "date-time",
+            "type": "string",
+            "x-order": 7
+          },
+          "url": {
+            "description": "The canonical registry:// URL identifying the module.",
+            "type": "string",
+            "x-order": 8
+          }
+        },
+        "required": [
+          "latestVersion",
+          "name",
+          "publisher",
+          "source",
+          "system",
+          "updatedAt",
+          "url"
+        ],
+        "type": "object"
+      },
+      "TerraformModuleExample": {
+        "description": "TerraformModuleExample describes an example (examples/<name>/) shipped alongside the root module. Examples are reference material, so their files are preserved verbatim rather than parsed.",
+        "properties": {
+          "files": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The example files, keyed by path relative to the example directory.",
+            "type": "object",
+            "x-order": 2
+          },
+          "name": {
+            "description": "The example name (its directory under examples/).",
+            "type": "string",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "files",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TerraformModuleInput": {
+        "description": "TerraformModuleInput describes an input variable declared by a Terraform module.",
+        "properties": {
+          "defaultValue": {
+            "description": "The default value rendered as a string, if the variable declares one.",
+            "type": "string",
+            "x-order": 4
+          },
+          "description": {
+            "description": "The variable description, if any.",
+            "type": "string",
+            "x-order": 3
+          },
+          "name": {
+            "description": "The variable name.",
+            "type": "string",
+            "x-order": 1
+          },
+          "required": {
+            "description": "Whether the variable is required (declares no default).",
+            "type": "boolean",
+            "x-order": 5
+          },
+          "sensitive": {
+            "description": "Whether the variable is marked sensitive.",
+            "type": "boolean",
+            "x-order": 6
+          },
+          "type": {
+            "description": "The declared Terraform type of the variable, if any.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "name",
+          "required",
+          "sensitive"
+        ],
+        "type": "object"
+      },
+      "TerraformModuleOutput": {
+        "description": "TerraformModuleOutput describes an output declared by a Terraform module.",
+        "properties": {
+          "description": {
+            "description": "The output description, if any.",
+            "type": "string",
+            "x-order": 2
+          },
+          "name": {
+            "description": "The output name.",
+            "type": "string",
+            "x-order": 1
+          },
+          "sensitive": {
+            "description": "Whether the output is marked sensitive.",
+            "type": "boolean",
+            "x-order": 3
+          }
+        },
+        "required": [
+          "name",
+          "sensitive"
+        ],
+        "type": "object"
+      },
+      "TerraformModuleProviderRequirement": {
+        "description": "TerraformModuleProviderRequirement describes a provider a Terraform module requires.",
+        "properties": {
+          "name": {
+            "description": "The local provider name (e.g. 'aws').",
+            "type": "string",
+            "x-order": 1
+          },
+          "source": {
+            "description": "The provider source address (e.g. 'hashicorp/aws'), if declared.",
+            "type": "string",
+            "x-order": 2
+          },
+          "versionConstraint": {
+            "description": "The version constraint declared for the provider, if any.",
+            "type": "string",
+            "x-order": 3
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TerraformModuleSubmodule": {
+        "description": "TerraformModuleSubmodule describes a submodule (modules/<name>/) shipped alongside the root module, with its HCL parsed into the same shape as the root module.",
+        "properties": {
+          "inputs": {
+            "description": "The input variables declared by the submodule.",
+            "items": {
+              "$ref": "#/components/schemas/TerraformModuleInput"
+            },
+            "type": "array",
+            "x-order": 3
+          },
+          "name": {
+            "description": "The submodule name (its directory under modules/).",
+            "type": "string",
+            "x-order": 1
+          },
+          "outputs": {
+            "description": "The outputs declared by the submodule.",
+            "items": {
+              "$ref": "#/components/schemas/TerraformModuleOutput"
+            },
+            "type": "array",
+            "x-order": 4
+          },
+          "providerRequirements": {
+            "description": "The provider requirements declared by the submodule.",
+            "items": {
+              "$ref": "#/components/schemas/TerraformModuleProviderRequirement"
+            },
+            "type": "array",
+            "x-order": 5
+          },
+          "readme": {
+            "description": "The submodule README, rendered client-side. Absent when the submodule ships no README.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "inputs",
+          "name",
+          "outputs",
+          "providerRequirements"
+        ],
+        "type": "object"
+      },
+      "TerraformModuleVersion": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TerraformModule"
+          },
+          {
+            "description": "TerraformModuleVersion represents a specific published version of a Terraform module, including the metadata parsed from the module tarball at publish time.",
+            "properties": {
+              "examples": {
+                "description": "The examples (examples/<name>/) shipped alongside the root module.",
+                "items": {
+                  "$ref": "#/components/schemas/TerraformModuleExample"
+                },
+                "type": "array",
+                "x-order": 9
+              },
+              "inputs": {
+                "description": "The input variables declared by the root module.",
+                "items": {
+                  "$ref": "#/components/schemas/TerraformModuleInput"
+                },
+                "type": "array",
+                "x-order": 5
+              },
+              "outputs": {
+                "description": "The outputs declared by the root module.",
+                "items": {
+                  "$ref": "#/components/schemas/TerraformModuleOutput"
+                },
+                "type": "array",
+                "x-order": 6
+              },
+              "providerRequirements": {
+                "description": "The provider requirements declared by the root module.",
+                "items": {
+                  "$ref": "#/components/schemas/TerraformModuleProviderRequirement"
+                },
+                "type": "array",
+                "x-order": 7
+              },
+              "readme": {
+                "description": "The module README, rendered client-side. Absent when the module ships no README.",
+                "type": "string",
+                "x-order": 4
+              },
+              "sha256": {
+                "description": "The SHA-256 checksum of the module tarball.",
+                "type": "string",
+                "x-order": 2
+              },
+              "sizeBytes": {
+                "description": "The size of the module tarball in bytes.",
+                "format": "int64",
+                "type": "integer",
+                "x-order": 3
+              },
+              "submodules": {
+                "description": "The submodules (modules/<name>/) shipped alongside the root module.",
+                "items": {
+                  "$ref": "#/components/schemas/TerraformModuleSubmodule"
+                },
+                "type": "array",
+                "x-order": 8
+              },
+              "version": {
+                "description": "The semantic version of this module version.",
+                "type": "string",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "inputs",
+              "outputs",
+              "providerRequirements",
+              "sha256",
+              "sizeBytes",
               "version"
             ],
             "type": "object"
@@ -23830,7 +27069,7 @@
         "description": "TransferAllStacksRequest request object for `transferring` ownership of all stacks\nfrom one organization to another.",
         "properties": {
           "fromOrg": {
-            "description": "The \"from stack identifier\" fields are only to maintain compatibility with\nthe AdminTransferStackHandler. If unset will use the URL Route parameters\nfrom the request.",
+            "description": "The source organization to transfer stacks from. Must match the organization in the URL route.",
             "type": "string",
             "x-order": 1
           },
@@ -23846,21 +27085,270 @@
         ],
         "type": "object"
       },
+      "TransferEntity": {
+        "description": "Base class for entities that need to be transferred between organizations.",
+        "discriminator": {
+          "mapping": {
+            "TransferEntityEnvironment": "#/components/schemas/TransferEntityEnvironment",
+            "TransferEntityEnvironmentRename": "#/components/schemas/TransferEntityEnvironmentRename",
+            "TransferEntityInsightsAccount": "#/components/schemas/TransferEntityInsightsAccount",
+            "TransferEntityInsightsAccountRename": "#/components/schemas/TransferEntityInsightsAccountRename",
+            "TransferEntityRegistryPackage": "#/components/schemas/TransferEntityRegistryPackage",
+            "TransferEntityRegistryPackageRename": "#/components/schemas/TransferEntityRegistryPackageRename",
+            "TransferEntityStack": "#/components/schemas/TransferEntityStack",
+            "TransferEntityStackRename": "#/components/schemas/TransferEntityStackRename"
+          },
+          "propertyName": "kind"
+        },
+        "properties": {
+          "kind": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "type": "object"
+      },
+      "TransferEntityEnvironment": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntity"
+          },
+          {
+            "description": "Reference to an ESC environment involved in a transfer.",
+            "properties": {
+              "environmentName": {
+                "description": "The environment name.",
+                "type": "string",
+                "x-order": 2
+              },
+              "projectName": {
+                "description": "The project the environment belongs to.",
+                "type": "string",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "environmentName",
+              "projectName"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityEnvironmentRename": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntityEnvironment"
+          },
+          {
+            "description": "Reference to an ESC environment involved in a transfer.",
+            "properties": {
+              "renameAs": {
+                "$ref": "#/components/schemas/TransferEntityEnvironment",
+                "description": "Rename information for ESC environment.",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "renameAs"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityFailure": {
+        "description": "Describes an entity the service cannot transfer. Unlike a conflict (which the client can resolve via conflictsResolution), a failure is a service-side limitation.",
+        "properties": {
+          "entity": {
+            "$ref": "#/components/schemas/TransferEntity",
+            "description": "The reference of the entity that cannot be transferred.",
+            "x-order": 1
+          },
+          "failureDetails": {
+            "description": "Service-side reason the entity cannot be transferred.",
+            "type": "string",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "entity",
+          "failureDetails"
+        ],
+        "type": "object"
+      },
+      "TransferEntityInsightsAccount": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntity"
+          },
+          {
+            "description": "Reference to an Insights Account involved in a transfer.",
+            "properties": {
+              "name": {
+                "description": "The Insights account name.",
+                "type": "string",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityInsightsAccountRename": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntityInsightsAccount"
+          },
+          {
+            "description": "Reference to an Insights Account involved in a transfer.",
+            "properties": {
+              "renameAs": {
+                "$ref": "#/components/schemas/TransferEntityInsightsAccount",
+                "description": "Renamed information for Insights account.",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "renameAs"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityRegistryPackage": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntity"
+          },
+          {
+            "description": "Reference to a registry package involved in a transfer.",
+            "properties": {
+              "name": {
+                "description": "The package name.",
+                "type": "string",
+                "x-order": 3
+              },
+              "publisher": {
+                "description": "The package publisher.",
+                "type": "string",
+                "x-order": 2
+              },
+              "source": {
+                "description": "The package source (e.g. pulumi, opentofu).",
+                "type": "string",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "name",
+              "publisher",
+              "source"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityRegistryPackageRename": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntityRegistryPackage"
+          },
+          {
+            "description": "Reference to a registry package involved in a transfer.",
+            "properties": {
+              "renameAs": {
+                "$ref": "#/components/schemas/TransferEntityRegistryPackage",
+                "description": "Rename information for registry package.",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "renameAs"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityStack": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntity"
+          },
+          {
+            "description": "Reference to a stack involved in a transfer.",
+            "properties": {
+              "lastUpdate": {
+                "description": "Timestamp of the stack's last activated update start time. Omitted when the stack has no activated update yet.",
+                "format": "date-time",
+                "type": "string",
+                "x-order": 4
+              },
+              "projectName": {
+                "description": "The project the colliding stack belongs to.",
+                "type": "string",
+                "x-order": 1
+              },
+              "resourceCount": {
+                "description": "Number of resources currently managed by the stack, as reported by the stack's last activated update. Omitted when the stack has no activated update yet.",
+                "format": "int64",
+                "type": "integer",
+                "x-order": 3
+              },
+              "stackName": {
+                "description": "The colliding stack name.",
+                "type": "string",
+                "x-order": 2
+              }
+            },
+            "required": [
+              "projectName",
+              "stackName"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "TransferEntityStackRename": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransferEntityStack"
+          },
+          {
+            "description": "Reference to a stack involved in a transfer.",
+            "properties": {
+              "renameAs": {
+                "$ref": "#/components/schemas/TransferEntityStack",
+                "description": "Rename information for stack.",
+                "x-order": 1
+              }
+            },
+            "required": [
+              "renameAs"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "TransferStackRequest": {
         "description": "TransferStackRequest request object for `transferring` ownership of a stack between two organizations.",
         "properties": {
           "fromOrg": {
-            "description": "The organization to transfer the stack from.\nOnly used for compatibility with the AdminTransferStackHandler.\nIf unset, uses the URL route parameters from the request.",
+            "description": "The source organization to transfer the stack from. If unset, the organization from the URL route parameters is used.",
             "type": "string",
             "x-order": 3
           },
           "projectName": {
-            "description": "The project name. Only used for compatibility with the AdminTransferStackHandler.\nIf unset, uses the URL route parameters from the request.",
+            "description": "The project name of the stack to transfer. If unset, the project from the URL route parameters is used.",
             "type": "string",
             "x-order": 1
           },
           "stackName": {
-            "description": "The stack name. Only used for compatibility with the AdminTransferStackHandler.\nIf unset, uses the URL route parameters from the request.",
+            "description": "The name of the stack to transfer. If unset, the stack from the URL route parameters is used.",
             "type": "string",
             "x-order": 2
           },
@@ -24002,6 +27490,11 @@
       "UpdateAzureDevOpsAppIntegrationRequest": {
         "description": "Request body for creating or updating an Azure DevOps app integration for a Pulumi organization.",
         "properties": {
+          "disableCodeAccessForReviews": {
+            "description": "Whether to disable code access for AI reviews",
+            "type": "boolean",
+            "x-order": 6
+          },
           "disableDetailedDiff": {
             "description": "Whether detailed property-level diffs are disabled for PR comments",
             "type": "boolean",
@@ -24074,6 +27567,32 @@
         "required": [
           "description"
         ],
+        "type": "object"
+      },
+      "UpdateCustomVCSIntegrationRequest": {
+        "description": "Request to update an existing custom VCS integration. All fields are optional; only provided fields are updated. Use regenerateWebhookSecret to rotate the webhook HMAC secret.",
+        "properties": {
+          "baseUrl": {
+            "description": "Updated URL prefix for repositories covered by this integration",
+            "type": "string",
+            "x-order": 2
+          },
+          "environment": {
+            "description": "Updated ESC environment reference in 'project/envName' format",
+            "type": "string",
+            "x-order": 3
+          },
+          "name": {
+            "description": "Updated human-readable name for the integration",
+            "type": "string",
+            "x-order": 1
+          },
+          "regenerateWebhookSecret": {
+            "description": "When true, generates a new webhook HMAC secret and invalidates the previous one. The new secret is returned in the response.",
+            "type": "boolean",
+            "x-order": 4
+          }
+        },
         "type": "object"
       },
       "UpdateEnvironmentResponse": {
@@ -24229,6 +27748,7 @@
             "description": "Schedule for automated discovery scans (e.g., 'none', 'daily').",
             "enum": [
               "none",
+              "12h",
               "daily"
             ],
             "type": "string",
@@ -24237,7 +27757,13 @@
               "enumComments": "ScanSchedule represents the schedule for automated scans.",
               "enumFieldComments": [
                 "No automated scanning is configured.",
+                "Scans run automatically every 12 hours.",
                 "Scans run automatically on a daily schedule."
+              ],
+              "enumFieldNames": [
+                "None",
+                "TwelveHours",
+                "Daily"
               ],
               "enumTypeName": "ScanSchedule"
             }
@@ -24268,6 +27794,41 @@
         ],
         "type": "object"
       },
+      "UpdateNeoMemberUsageCapRequest": {
+        "description": "Request body for the self-serve UpdateNeoMemberUsageCap endpoint. Sets or replaces a member's monthly Neo usage cap. To remove the cap, call DeleteNeoMemberUsageCap rather than sending capCents=0.",
+        "properties": {
+          "capCents": {
+            "description": "Monthly cap in US-dollar cents. Must be at least 1000 ($10, the self-serve floor) and at most 100_000_000 ($1M). Outside that range the call returns 400.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 1
+          }
+        },
+        "required": [
+          "capCents"
+        ],
+        "type": "object"
+      },
+      "UpdateNeoUsageCapRequest": {
+        "description": "Request body for the self-serve UpdateNeoUsageCap endpoint. Sets or replaces the org's monthly Neo usage cap. To remove the cap, call DeleteNeoUsageCap rather than sending capCents=0.",
+        "properties": {
+          "capCents": {
+            "description": "Monthly cap in US-dollar cents. Must be at least 1000 ($10, the self-serve floor) and at most 100_000_000 ($1M). Outside that range the call returns 400.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 1
+          },
+          "notificationsEnabled": {
+            "description": "Whether to send threshold-warning emails (50/80/95/100% of the cap) to billing admins. Omit (null) to leave the current setting unchanged; new caps default to enabled.",
+            "type": "boolean",
+            "x-order": 2
+          }
+        },
+        "required": [
+          "capCents"
+        ],
+        "type": "object"
+      },
       "UpdateOrganizationAuditLogExportSettingsRequest": {
         "description": "UpdateOrganizationAuditLogExportSettingsRequest is the request type when making\nchanges to an existing audit log export configuration.",
         "properties": {
@@ -24292,12 +27853,12 @@
         "description": "UpdateOrganizationMemberRequest is the request type for updating an organization member.",
         "properties": {
           "fgaRoleId": {
-            "description": "FGARoleID is the ID of a custom role to assign to the member. This is used with the new RBAC system.\nIf both Role and FGARoleID are provided, FGARoleID takes precedence.",
+            "description": "The ID of a custom role to assign to the member. If both `role` and `fgaRoleId` are provided, `fgaRoleId` takes precedence.",
             "type": "string",
             "x-order": 2
           },
           "role": {
-            "description": "Role is the new role to give the member. Must be one of MEMBER or ADMIN (a member can't be updated\nto a Billing Manager). This is used for backwards compatibility with the legacy role system.",
+            "description": "The built-in role to assign to the member. Must be `member`, `admin`, or `billing-manager`. Ignored if `fgaRoleId` is also set.",
             "enum": [
               "none",
               "member",
@@ -24368,6 +27929,16 @@
               "enumTypeName": "InsightsAccountPermission"
             }
           },
+          "setDefaultAgentPoolID": {
+            "description": "The ID of the default agent pool for the organization. Set to empty string to revert to the Pulumi Hosted Pool.",
+            "type": "string",
+            "x-order": 19
+          },
+          "setDefaultDeploymentRoleId": {
+            "description": "The ID of the default deployment role. When set, this role is applied to all deployments that do not have a role explicitly configured in their stack deployment settings. Set to an empty string to clear the default.",
+            "type": "string",
+            "x-order": 18
+          },
           "setDefaultEnvironmentPermission": {
             "description": "The new default environment permission for the organization.",
             "enum": [
@@ -24415,6 +27986,12 @@
               "enumTypeName": "StackPermission"
             }
           },
+          "setMaxAccessTokenExpiryDays": {
+            "description": "The maximum allowed access token expiry, in days, for personal, organization, and team access tokens used against this organization. A value of 0 clears the policy (the prior default behavior, in which tokens may have any expiry or no expiry). A positive value requires every token to have an expiry, and the remaining lifetime of the token must not exceed this many days. Web sessions and system-managed tokens (deployment runners, agent pools, stack tokens) are not subject to this policy. Leave the field unset to make no change to the existing policy value.",
+            "format": "int64",
+            "type": "integer",
+            "x-order": 20
+          },
           "setMembersCanCreateAccounts": {
             "description": "Whether members can create accounts.",
             "type": "boolean",
@@ -24445,6 +28022,16 @@
             "type": "boolean",
             "x-order": 7
           },
+          "setNaturalLanguageSearchDisabled": {
+            "description": "Whether natural-language resource search is disabled for the organization. Independent of setNeoEnabled; if the master is disabled, this flag has no additional effect.",
+            "type": "boolean",
+            "x-order": 15
+          },
+          "setNeoAgentDisabled": {
+            "description": "Whether the Neo agent is disabled for the organization. Independent of setNeoEnabled; if the master is disabled, this flag has no additional effect.",
+            "type": "boolean",
+            "x-order": 16
+          },
           "setNeoApprovalMode": {
             "description": "The default approval mode for Neo tasks.",
             "enum": [
@@ -24458,6 +28045,11 @@
               "enumComments": "NeoApprovalMode represents the default approval mode for Neo AI agent tasks in an organization",
               "enumTypeName": "NeoApprovalMode"
             }
+          },
+          "setNeoCLIExplanationsDisabled": {
+            "description": "Whether Neo CLI explanations (preview and update-failure explanations served to the CLI) are disabled for the organization. Independent of setNeoEnabled; if the master is disabled, this flag has no additional effect.",
+            "type": "boolean",
+            "x-order": 14
           },
           "setNeoEnabled": {
             "description": "Whether Neo is enabled for the organization.",
@@ -24486,7 +28078,7 @@
               "gitlab"
             ],
             "type": "string",
-            "x-order": 14,
+            "x-order": 17,
             "x-pulumi-model-property": {
               "enumComments": "PreferredVCS represents an organization selected preferred VCS vendor",
               "enumFieldNames": [
@@ -24554,7 +28146,7 @@
             }
           },
           "status": {
-            "description": "The new status for the policy issue. Valid values: open, in_progress, by_design, ignored. Note: fixed cannot be set manually.",
+            "description": "The new status for the policy issue. Valid values: open, in_progress, ignored. Note: fixed and by_design cannot be set manually.",
             "enum": [
               "open",
               "in_progress",
@@ -24580,29 +28172,24 @@
         "type": "object"
       },
       "UpdateRoleRequest": {
-        "description": "Request to update a custom role.",
+        "description": "Request to update a custom role. All fields are optional; only fields present in the request are updated on the server.",
         "properties": {
-          "Description": {
+          "description": {
             "description": "The new description for the role.",
             "type": "string",
             "x-order": 2
           },
-          "Details": {
+          "details": {
             "$ref": "#/components/schemas/PermissionDescriptor",
             "description": "The permission details for the role.",
             "x-order": 3
           },
-          "Name": {
+          "name": {
             "description": "The new name for the role.",
             "type": "string",
             "x-order": 1
           }
         },
-        "required": [
-          "Description",
-          "Details",
-          "Name"
-        ],
         "type": "object"
       },
       "UpdateSAMLOrganizationRequest": {
@@ -24708,16 +28295,16 @@
             "x-pulumi-model-property": {
               "enumComments": "UpdateResult is an enum for the result of the update.\nShould generally mirror backend.UpdateResult, but we clone it in this package to add\nflexibility in case there is a breaking change in the backend-type.",
               "enumFieldComments": [
-                "NotStartedResult is for updates that have not started.",
-                "InProgressResult is for updates that have not yet completed.",
-                "SucceededResult is for updates that completed successfully.",
-                "FailedResult is for updates that have failed."
+                "The update has not started.",
+                "The update has not yet completed.",
+                "The update completed successfully.",
+                "The update has failed."
               ],
               "enumFieldNames": [
-                "NotStartedResult",
-                "InProgressResult",
-                "SucceededResult",
-                "FailedResult"
+                "NotStarted",
+                "InProgress",
+                "Succeeded",
+                "Failed"
               ],
               "enumTypeName": "AppUpdateResult"
             }
@@ -25014,6 +28601,55 @@
         ],
         "type": "object"
       },
+      "UpsertResourceMigrationAnnotationRequest": {
+        "description": "Request to create or update a migration annotation on a discovered resource.",
+        "properties": {
+          "linkedResourceUrn": {
+            "description": "URN of the resource this one was migrated as part of.",
+            "type": "string",
+            "x-order": 4
+          },
+          "note": {
+            "description": "Free-text note about this resource. May be empty when only setting a status override.",
+            "type": "string",
+            "x-order": 2
+          },
+          "resourceUrn": {
+            "description": "URN of the resource to annotate.",
+            "type": "string",
+            "x-order": 1
+          },
+          "statusOverride": {
+            "description": "Override the computed migration status. Only Migrated and NotApplicable are valid values.",
+            "enum": [
+              "Migrated",
+              "PulumiOnly",
+              "Ready",
+              "Pending",
+              "Unmapped",
+              "NotApplicable"
+            ],
+            "type": "string",
+            "x-order": 3,
+            "x-pulumi-model-property": {
+              "enumComments": "Migration status of a discovered resource relative to a comparison Pulumi stack. Migrated and PulumiOnly are only possible when the compareTo parameter is provided.",
+              "enumFieldComments": [
+                "Resource identity match found in the comparison stack.",
+                "Resource exists only in the comparison Pulumi stack.",
+                "Mapped to a Pulumi type with virtual state available.",
+                "Mapped to a Pulumi type but no virtual state yet.",
+                "No Pulumi type mapping exists for this resource.",
+                "Migration status is not applicable (e.g. stack or deployment containers)."
+              ],
+              "enumTypeName": "MigrationStatus"
+            }
+          }
+        },
+        "required": [
+          "resourceUrn"
+        ],
+        "type": "object"
+      },
       "UsageRecord": {
         "allOf": [
           {
@@ -25093,6 +28729,11 @@
             },
             "type": "array",
             "x-order": 8
+          },
+          "isAgent": {
+            "description": "Whether the user is a synthetic agent account. Agent accounts cannot be authenticated except via their issued access token until a human claims the account via the claim URL.",
+            "type": "boolean",
+            "x-order": 15
           },
           "isManagedByMultiOrg": {
             "description": "Whether the user's account is managed by multiple organizations.",
@@ -25323,6 +28964,11 @@
             "type": "string",
             "x-order": 2
           },
+          "baseUrl": {
+            "description": "The base URL for custom VCS integrations (e.g., \"https://github.com/myorg\" or \"git@git.sr.ht:~user\"). Used by the console to construct repository URLs. Empty for native providers.",
+            "type": "string",
+            "x-order": 7
+          },
           "hasIndividualAccess": {
             "description": "Whether the current user has an OAuth token for this integration's provider.",
             "type": "boolean",
@@ -25350,6 +28996,7 @@
               "gitlab",
               "bitbucket",
               "azure_devops",
+              "custom",
               "github_enterprise"
             ],
             "type": "string",
@@ -25361,6 +29008,7 @@
                 "GitLab version control system",
                 "Bitbucket version control system",
                 "Azure DevOps version control system",
+                "Custom version control system",
                 "GitHub Enterprise Server version control system"
               ],
               "enumFieldNames": [
@@ -25368,6 +29016,7 @@
                 "GitLab",
                 "Bitbucket",
                 "AzureDevOps",
+                "Custom",
                 "GitHubEnterprise"
               ],
               "enumTypeName": "VCSProvider"
@@ -25447,7 +29096,7 @@
             "x-order": 12
           },
           "name": {
-            "description": "The unique identifier name for the webhook within its scope.",
+            "description": "The unique identifier name for the webhook within its scope. Optional on creation; if omitted, the service generates a short random name. Always populated in responses.",
             "type": "string",
             "x-order": 5
           },
@@ -25480,7 +29129,6 @@
         "required": [
           "active",
           "displayName",
-          "name",
           "organizationName",
           "payloadUrl"
         ],
@@ -25688,7 +29336,7 @@
             "x-order": 1
           },
           "important": {
-            "description": "Important indicates the template is important. Deprecated: We don't use this field any more.",
+            "description": "Indicates the template is important. Deprecated: this field is no longer used.",
             "type": "boolean",
             "x-order": 5
           },
@@ -26174,8 +29822,211 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/api/agents/signup": {
+      "get": {
+        "description": "Issues a proof-of-work challenge for the agent signup flow. The caller computes the proof over the returned challengeData and submits the result to POST /api/agents/signup along with the returned challengeID. The challenge expires after a short window if not consumed.",
+        "operationId": "SignupChallenge",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSignupChallenge"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "SignupChallenge",
+        "tags": [
+          "AI Agents"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "post": {
+        "description": "Creates a new Pulumi Cloud account programmatically, without human intervention, and returns an access token plus a claim URL. The caller must first obtain a challenge from GET /api/agents/signup/challenge and submit the computed proof of work here. Intended for agent contexts: a CLI that detects it is running on behalf of an agent and finds no local credentials issues the challenge call, solves it, then calls this endpoint, writes the returned access token to its credentials file, and surfaces the claim URL to its human so the human can take ownership of the account later. The account is a Pulumi Individual Account in a pre-claim state; operations that require a verified email (such as creating agent tasks) are unavailable until the account is claimed.",
+        "operationId": "Signup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentSignupRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSignupResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Missing or invalid challengeID / challengeResult, or proof-of-work verification failed."
+          }
+        },
+        "summary": "Signup",
+        "tags": [
+          "AI Agents"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/agents/signup/validate/{claimToken}": {
+      "get": {
+        "description": "Verifies the claim token is still valid. It returns the details about the agent and the resources it created",
+        "operationId": "SignupValidate",
+        "parameters": [
+          {
+            "description": "The claim token generated by the Agent Signup",
+            "in": "path",
+            "name": "claimToken",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentClaimResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Claim token is unknown, expired, or already canceled"
+          }
+        },
+        "summary": "SignupValidate",
+        "tags": [
+          "AI Agents"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/agents/{orgName}/claim": {
+      "post": {
+        "description": "Previews the agent claim (dryRun=true) or starts its commit. The response shape is identical in both cases. Commit transfers the agent's stacks to the destination organization, soft-deletes the agent's organization, and soft-deletes the agent's access token. If there are unresolved conflicts or failures, it returns them and does not perform any state mutations.",
+        "operationId": "Claim",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "If set, perform a dry run without committing changes",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentClaimRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentClaimResponse"
+                }
+              }
+            },
+            "description": "OK (preview, successful commit, or commit blocked); inspect conflicts and failures to distinguish"
+          },
+          "400": {
+            "description": "Missing claimToken or unsupported conflictsResolution"
+          },
+          "403": {
+            "description": "Caller has no role in the destination organization, or is the agent itself"
+          },
+          "404": {
+            "description": "Claim token is unknown, expired, or already canceled"
+          }
+        },
+        "summary": "Claim",
+        "tags": [
+          "AI Agents"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/agents/{orgName}/claim/status": {
+      "get": {
+        "description": "Fetches details from recent agent claims.",
+        "operationId": "ClaimStatus",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentClaimsStatus"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "description": "Caller has no role in the destination organization, or is the agent itself"
+          }
+        },
+        "summary": "ClaimStatus",
+        "tags": [
+          "AI Agents"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
     "/api/ai/template": {
       "post": {
+        "deprecated": true,
         "description": "Generates a Pulumi template using the Pulumi AI service.",
         "operationId": "AITemplate",
         "requestBody": {
@@ -26203,7 +30054,11 @@
         "summary": "AITemplate",
         "tags": [
           "AI"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "Visibility": "Public"
+        }
       }
     },
     "/api/capabilities": {
@@ -26844,6 +30699,57 @@
         ]
       }
     },
+    "/api/change-requests/{orgName}/{changeRequestID}/comments": {
+      "post": {
+        "description": "Adds a comment to a change request without approving or closing it. This allows reviewers to provide feedback or ask questions before making a decision.",
+        "operationId": "AddComment",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The change request identifier",
+            "in": "path",
+            "name": "changeRequestID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddChangeRequestCommentRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "bad request"
+          },
+          "404": {
+            "description": "not found"
+          }
+        },
+        "summary": "AddChangeRequestComment",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
     "/api/change-requests/{orgName}/{changeRequestID}/events": {
       "get": {
         "description": "Lists the event log for a change request, including approvals, status changes, and other lifecycle events. Supports pagination via continuation token.",
@@ -26975,7 +30881,7 @@
     },
     "/api/console/orgs/{orgName}/integrations": {
       "get": {
-        "description": "Returns a summary of all VCS integrations across all providers (GitHub, GitLab, Azure DevOps) for an organization. Each integration includes a hasIndividualAccess flag indicating whether the current user has an OAuth token for that provider.",
+        "description": "Returns a summary of all VCS integrations across all providers (GitHub, GitLab, Azure DevOps, Custom) for an organization. Each integration includes a hasIndividualAccess flag indicating whether the current user has an OAuth token for that provider.",
         "operationId": "ListAllVCSIntegrations",
         "parameters": [
           {
@@ -27079,7 +30985,10 @@
         "summary": "CreateAzureDevOpsSetup",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/azure-devops/access-status": {
@@ -27158,7 +31067,10 @@
         "summary": "CompleteAzureDevOpsOAuth",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/azure-devops/oauth/initiate": {
@@ -27204,7 +31116,10 @@
         "summary": "InitiateAzureDevOpsOAuth",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/azure-devops/setup/organizations": {
@@ -27240,7 +31155,10 @@
         "summary": "ListAzureDevOpsOrganizations",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/azure-devops/setup/organizations/{adoOrgName}/projects": {
@@ -27285,7 +31203,10 @@
         "summary": "ListAzureDevOpsProjects",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/azure-devops/{integrationId}": {
@@ -27418,6 +31339,589 @@
         ]
       }
     },
+    "/api/console/orgs/{orgName}/integrations/bitbucket": {
+      "get": {
+        "description": "Lists all BitBucket integrations configured for an organization, including their validity status and linked workspace metadata.",
+        "operationId": "ListBitBucketIntegrations",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListBitBucketIntegrationsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ListBitBucketIntegrations",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "post": {
+        "description": "Creates a new BitBucket integration for an organization. Requires a BitBucket workspace UUID and optionally configures authentication via the user's BitBucket OAuth token or a workspace access token / PAT. Returns 409 if an integration already exists for the specified workspace.",
+        "operationId": "CreateBitBucketSetup",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BitBucketSetupRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "Created successfully"
+          },
+          "400": {
+            "description": "Missing or invalid BitBucket workspace"
+          },
+          "409": {
+            "description": "BitBucket integration already exists for this workspace"
+          }
+        },
+        "summary": "CreateBitBucketSetup",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/bitbucket/access-status": {
+      "get": {
+        "description": "Returns information about a user's BitBucket access status for an organization, including whether they have a valid OAuth token and available BitBucket workspaces for new integrations.",
+        "operationId": "GetBitBucketAccessStatus",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BitBucketAccessStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "GetBitBucketAccessStatus",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/bitbucket/{integrationId}": {
+      "delete": {
+        "description": "Removes a specific BitBucket integration from the organization. Cleans up associated webhooks and access tokens.",
+        "operationId": "DeleteBitBucketIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The BitBucket integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "DeleteBitBucketIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "get": {
+        "description": "Gets a specific BitBucket integration by its integration ID. Returns the integration details including the linked BitBucket workspace, authentication configuration, and validity status.",
+        "operationId": "GetBitBucketIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The BitBucket integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BitBucketIntegrationDetails"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "BitBucket integration not found"
+          }
+        },
+        "summary": "GetBitBucketIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "patch": {
+        "description": "Updates an existing BitBucket integration's settings, such as PR comment preferences and AI summary options.",
+        "operationId": "UpdateBitBucketIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The BitBucket integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BitBucketSettingsRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "BitBucket integration not found"
+          }
+        },
+        "summary": "UpdateBitBucketIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/custom": {
+      "get": {
+        "description": "Lists all custom VCS integrations configured for an organization. Returns each integration's configuration, webhook URL, and configured repositories. Webhook secrets are not included in list responses.",
+        "operationId": "ListCustomVCSIntegrations",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCustomVCSIntegrationsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ListCustomVCSIntegrations",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "post": {
+        "description": "Creates a new custom VCS integration for an organization. Custom VCS integrations allow connecting self-hosted or third-party version control systems (e.g. Gitea, Forgejo, Bitbucket Server) to Pulumi Deployments. Credentials are managed via ESC environments, and deployments are triggered by inbound webhooks. Returns the created integration including its webhook URL and HMAC secret for signature verification.",
+        "operationId": "CreateCustomVCSIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomVCSIntegrationRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomVCSIntegrationResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "description": "Invalid request: missing required fields or invalid vcsType"
+          },
+          "409": {
+            "description": "An integration with this name already exists in the organization"
+          }
+        },
+        "summary": "CreateCustomVCSIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/custom/{integrationId}": {
+      "delete": {
+        "description": "Removes a specific custom VCS integration from the organization. This permanently deletes the integration, its webhook endpoint, and all configured repository associations.",
+        "operationId": "DeleteCustomVCSIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The custom VCS integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Custom VCS integration not found"
+          }
+        },
+        "summary": "DeleteCustomVCSIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "get": {
+        "description": "Gets a specific custom VCS integration by its integration ID. Returns the integration details including its configuration, webhook URL, and configured repositories. The webhook secret is not included; it is only returned at creation time or when regenerated via update.",
+        "operationId": "GetCustomVCSIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The custom VCS integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomVCSIntegrationResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Custom VCS integration not found"
+          }
+        },
+        "summary": "GetCustomVCSIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "patch": {
+        "description": "Updates an existing custom VCS integration's settings. All fields are optional; only provided fields are modified. Set regenerateWebhookSecret to true to rotate the webhook HMAC secret, which invalidates the previous secret immediately.",
+        "operationId": "UpdateCustomVCSIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The custom VCS integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomVCSIntegrationRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomVCSIntegrationResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid request: invalid vcsType or other validation failure"
+          },
+          "404": {
+            "description": "Custom VCS integration not found"
+          }
+        },
+        "summary": "UpdateCustomVCSIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/custom/{integrationId}/repos": {
+      "delete": {
+        "description": "Removes a repository from a custom VCS integration. The repository is identified by its name, as provided in the request. Returns 404 if the integration or repository is not found.",
+        "operationId": "RemoveCustomVCSRepository",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The custom VCS integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveCustomVCSRepositoryRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Custom VCS integration or repository not found"
+          }
+        },
+        "summary": "RemoveCustomVCSRepository",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "post": {
+        "description": "Adds a repository to a custom VCS integration. The repository name must be unique within the integration. Returns 409 Conflict if a repository with the same name is already configured.",
+        "operationId": "AddCustomVCSRepository",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The custom VCS integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddCustomVCSRepositoryRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Custom VCS integration not found"
+          },
+          "409": {
+            "description": "Repository name already configured on this integration"
+          }
+        },
+        "summary": "AddCustomVCSRepository",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
     "/api/console/orgs/{orgName}/integrations/github": {
       "get": {
         "description": "Lists all GitHub App integrations for an organization.",
@@ -27479,7 +31983,10 @@
         "summary": "StartGitHubSetup",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/github-enterprise": {
@@ -27645,6 +32152,177 @@
         ]
       }
     },
+    "/api/console/orgs/{orgName}/integrations/github-enterprise/{integrationId}/user-auth": {
+      "delete": {
+        "description": "Disconnects the current user's linked GitHub Enterprise identity for the given integration's host by deleting the stored user access token and identity rows. Because the identity is stored once per (user, GHE host), this also disconnects the user from every other organization whose App is on the same host. Idempotent: succeeds even if no identity is currently linked.",
+        "operationId": "DeleteGitHubEnterpriseUserAuth",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The GitHub Enterprise integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "GitHub Enterprise integration not found"
+          }
+        },
+        "summary": "DeleteGitHubEnterpriseUserAuth",
+        "tags": [
+          "VCS Integrations"
+        ]
+      },
+      "get": {
+        "description": "Returns the GitHub Enterprise identity the current user has linked for the given integration's host, including the GitHub login, numeric user ID, and the time the identity was linked. The identity is stored once per (user, GHE host), so the same identity is returned for every organization whose App is on that host; the integration only selects the host. Returns 404 if the user has not linked an identity on that host.",
+        "operationId": "GetGitHubEnterpriseUserIdentity",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The GitHub Enterprise integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitHubEnterpriseUserIdentityResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "GitHub Enterprise integration not found, or the user has not linked an identity"
+          }
+        },
+        "summary": "GetGitHubEnterpriseUserIdentity",
+        "tags": [
+          "VCS Integrations"
+        ]
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/github-enterprise/{integrationId}/user-auth/authorize": {
+      "get": {
+        "description": "Returns the GitHub Enterprise OAuth authorization URL the console should redirect the current user to in order to link their GitHub Enterprise identity for the given integration's host. The URL carries the integration's App client_id, the service-side callback as the redirect_uri, and a signed state parameter that binds the authorization to the current user and host.",
+        "operationId": "GetGitHubEnterpriseAuthorizeURL",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The GitHub Enterprise integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitHubEnterpriseAuthorizeURLResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "GitHub Enterprise integration not found"
+          }
+        },
+        "summary": "GetGitHubEnterpriseAuthorizeURL",
+        "tags": [
+          "VCS Integrations"
+        ]
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/github-enterprise/{integrationId}/user-auth/members": {
+      "get": {
+        "description": "Returns the github.com logins of organization members who have linked a GitHub Enterprise identity on the given integration's host. Backs the organization members admin view's indicator of which members are connected for per-user GitHub Enterprise auth. Link status is per (user, GHE host); the integration only selects the host, so a member counts as linked when they have an identity on that host. Returns an empty list when no members are linked or the integration has no GitHub Enterprise host.",
+        "operationId": "ListGitHubEnterpriseLinkedMembers",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The GitHub Enterprise integration identifier",
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitHubEnterpriseLinkedMembersResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "GitHub Enterprise integration not found"
+          }
+        },
+        "summary": "ListGitHubEnterpriseLinkedMembers",
+        "tags": [
+          "VCS Integrations"
+        ]
+      }
+    },
     "/api/console/orgs/{orgName}/integrations/github/access-status": {
       "get": {
         "description": "Returns information about a user's GitHub OAuth status.",
@@ -27679,6 +32357,97 @@
         "tags": [
           "VCS Integrations"
         ]
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/github/claim": {
+      "post": {
+        "description": "Links an existing, unlinked Pulumi GitHub App installation (for example one installed directly from the GitHub Marketplace) to the organization. The caller must be able to update organization integrations, and must control the installation on the GitHub side, verified via the caller's GitHub identity (their GitHub OAuth token, or a matching GitHub account for the user or organization). Idempotent when the installation is already linked to this organization. Returns 409 if the installation is linked to a different organization; contact support to move an installation between organizations.",
+        "operationId": "ClaimGitHubIntegration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClaimGitHubIntegrationRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitHubIntegrationDetails"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "description": "The caller could not be verified as controlling this GitHub App installation"
+          },
+          "404": {
+            "description": "GitHub App installation not found"
+          },
+          "409": {
+            "description": "The installation is already linked to another organization"
+          }
+        },
+        "summary": "ClaimGitHubIntegration",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/console/orgs/{orgName}/integrations/github/claimable": {
+      "get": {
+        "description": "Lists Pulumi GitHub App installations that are not linked to any Pulumi organization and that the caller could link to this organization. Candidates are discovered through the caller's GitHub OAuth token and, for GitHub-backed organizations, through the organization's GitHub account. Returns an empty list when the caller has no GitHub OAuth token and no candidates can be discovered; connect a GitHub account to discover more installations.",
+        "operationId": "ListClaimableGitHubIntegrations",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClaimableGitHubIntegrationsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ListClaimableGitHubIntegrations",
+        "tags": [
+          "VCS Integrations"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/github/{integrationId}": {
@@ -27881,7 +32650,10 @@
         "summary": "CreateGitLabSetup",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/gitlab/access-status": {
@@ -28069,6 +32841,7 @@
                 "gitlab",
                 "bitbucket",
                 "azure_devops",
+                "custom",
                 "github_enterprise"
               ],
               "type": "string",
@@ -28079,6 +32852,7 @@
                   "GitLab version control system",
                   "Bitbucket version control system",
                   "Azure DevOps version control system",
+                  "Custom version control system",
                   "GitHub Enterprise Server version control system"
                 ],
                 "enumFieldNames": [
@@ -28086,6 +32860,7 @@
                   "GitLab",
                   "Bitbucket",
                   "AzureDevOps",
+                  "Custom",
                   "GitHubEnterprise"
                 ],
                 "enumTypeName": "VCSProvider"
@@ -28135,7 +32910,10 @@
         "summary": "ListVCSRepos",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/{provider}/{integrationId}/repos/destinations": {
@@ -28163,6 +32941,7 @@
                 "gitlab",
                 "bitbucket",
                 "azure_devops",
+                "custom",
                 "github_enterprise"
               ],
               "type": "string",
@@ -28173,6 +32952,7 @@
                   "GitLab version control system",
                   "Bitbucket version control system",
                   "Azure DevOps version control system",
+                  "Custom version control system",
                   "GitHub Enterprise Server version control system"
                 ],
                 "enumFieldNames": [
@@ -28180,6 +32960,7 @@
                   "GitLab",
                   "Bitbucket",
                   "AzureDevOps",
+                  "Custom",
                   "GitHubEnterprise"
                 ],
                 "enumTypeName": "VCSProvider"
@@ -28217,7 +32998,10 @@
         "summary": "ListVCSRepoDestinations",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/integrations/{provider}/{integrationId}/repos/{repoId}/branches": {
@@ -28245,6 +33029,7 @@
                 "gitlab",
                 "bitbucket",
                 "azure_devops",
+                "custom",
                 "github_enterprise"
               ],
               "type": "string",
@@ -28255,6 +33040,7 @@
                   "GitLab version control system",
                   "Bitbucket version control system",
                   "Azure DevOps version control system",
+                  "Custom version control system",
                   "GitHub Enterprise Server version control system"
                 ],
                 "enumFieldNames": [
@@ -28262,6 +33048,7 @@
                   "GitLab",
                   "Bitbucket",
                   "AzureDevOps",
+                  "Custom",
                   "GitHubEnterprise"
                 ],
                 "enumTypeName": "VCSProvider"
@@ -28308,7 +33095,10 @@
         "summary": "ListVCSBranches",
         "tags": [
           "VCS Integrations"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/orgs/{orgName}/members/{userLogin}/stacks/{projectName}/{stackName}": {
@@ -28374,6 +33164,127 @@
         ]
       }
     },
+    "/api/console/orgs/{orgName}/neo/member-usage-caps": {
+      "get": {
+        "description": "Returns every organization member joined with their per-member monthly Neo usage cap, their month-to-date Neo spend, and their effective limit (the smaller of the per-member and org-level caps). Caps are denominated in cents.",
+        "operationId": "ListNeoMemberUsageCaps",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NeoMemberUsageCaps"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ListNeoMemberUsageCaps",
+        "tags": [
+          "Neo"
+        ]
+      }
+    },
+    "/api/console/orgs/{orgName}/neo/member-usage-caps/{userID}": {
+      "delete": {
+        "description": "Removes the monthly Neo usage cap for a single member, returning them to only the org-level cap (if any). Idempotent — deleting when no cap is set returns 204.",
+        "operationId": "DeleteNeoMemberUsageCap",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The member's user ID",
+            "in": "path",
+            "name": "userID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "DeleteNeoMemberUsageCap",
+        "tags": [
+          "Neo"
+        ]
+      },
+      "put": {
+        "description": "Creates or replaces the monthly Neo usage cap for a single member of an organization. The cap must be at least $10/month. To remove the cap, call DeleteNeoMemberUsageCap.",
+        "operationId": "UpdateNeoMemberUsageCap",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The member's user ID",
+            "in": "path",
+            "name": "userID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNeoMemberUsageCapRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NeoMemberUsageCap"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid cap configuration or user is not a member of the organization"
+          }
+        },
+        "summary": "UpdateNeoMemberUsageCap",
+        "tags": [
+          "Neo"
+        ]
+      }
+    },
     "/api/console/orgs/{orgName}/stacks/search": {
       "post": {
         "description": "Returns a combined view of IaC-managed stacks and discovered stacks.",
@@ -28416,8 +33327,12 @@
         },
         "summary": "SearchStacks",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/console/stacks/{orgName}/{projectName}/{stackName}/overview": {
@@ -29114,7 +34029,7 @@
     },
     "/api/esc/cloudsetup/{orgName}/oauth/gcp/accounts": {
       "get": {
-        "description": "Lists GCP projects accessible with the provided oauth session",
+        "description": "Lists GCP projects accessible with the provided OAuth session. When 'gcpOrganizationId' is provided, discovery is scoped to that GCP organization: results include projects directly under the organization and projects nested under its descendant folders, and a 400 is returned if the ID is malformed or returned no projects. When 'gcpOrganizationId' is omitted, all active projects the OAuth principal can access are returned regardless of organization. System-generated projects (IDs prefixed 'sys-') and projects pending deletion are excluded in both cases.",
         "operationId": "GCPListAccounts",
         "parameters": [
           {
@@ -29127,7 +34042,15 @@
             }
           },
           {
-            "description": "The OAuth session identifier",
+            "description": "Optional GCP numeric organization ID. When provided, results are scoped to projects directly under this organization and projects nested under its descendant folders; when omitted, all accessible projects are returned. Find it in the Google Cloud console under IAM & Admin > Settings.",
+            "in": "query",
+            "name": "gcpOrganizationId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The OAuth session identifier. Required; returns 400 when missing.",
             "in": "query",
             "name": "oauthSessionId",
             "schema": {
@@ -29147,7 +34070,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "Failed to list gcp projects"
+            "description": "Failed to list gcp projects, or 'gcpOrganizationId' is malformed or returned no projects"
           },
           "404": {
             "description": "Organization or Session not found"
@@ -29268,7 +34191,7 @@
             }
           },
           {
-            "description": "Whether to include referrer metadata. Defaults to false.",
+            "description": "Deprecated. No longer used; referrer metadata is no longer computed and this parameter is ignored.",
             "in": "query",
             "name": "includeReferrerMetadata",
             "schema": {
@@ -29337,7 +34260,7 @@
             }
           },
           {
-            "description": "Whether to include referrer metadata. Defaults to false.",
+            "description": "Deprecated. No longer used; referrer metadata is no longer computed and this parameter is ignored.",
             "in": "query",
             "name": "includeReferrerMetadata",
             "schema": {
@@ -31506,6 +36429,68 @@
           }
         },
         "summary": "ReadOpenEnvironment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/api/esc/environments/{orgName}/{projectName}/{envName}/ownership": {
+      "post": {
+        "description": "Changes the ownership of the specified environment to the provided user. Returns the identity of the previous owner.",
+        "operationId": "ReassignEnvironmentOwnership",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The project name",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The environment name",
+            "in": "path",
+            "name": "envName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInfo"
+              }
+            }
+          },
+          "description": "The new owner's identity",
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserInfo"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ReassignEnvironmentOwnership",
         "tags": [
           "Environments"
         ]
@@ -33794,7 +38779,7 @@
     },
     "/api/oauth/token": {
       "post": {
-        "description": "Exchanges an external identity provider token for a Pulumi access token using the OAuth 2.0 Token Exchange flow (RFC 8693). The request body must include: audience (a URN identifying the target, e.g. 'urn:pulumi:org:{ORG_NAME}'), grant_type (must be 'urn:ietf:params:oauth:grant-type:token-exchange'), subject_token (the OIDC identity token from the external provider), subject_token_type (must be 'urn:ietf:params:oauth:token-type:id_token'), and requested_token_type (such as 'urn:pulumi:token-type:access_token:organization', 'urn:pulumi:token-type:access_token:team', 'urn:pulumi:token-type:access_token:personal', or 'urn:pulumi:token-type:access_token:runner'). Optional parameters include scope (requested permissions, e.g. specific team memberships) and expiration (token lifetime in seconds). The response includes the Pulumi access_token, issued_token_type, and token_type fields.",
+        "description": "Exchanges a presented credential for a Pulumi access token. Two grant types are supported, selected by the `grant_type` field in the request body.\n\n**Token exchange** (RFC 8693). Exchanges an external OIDC identity provider token for a Pulumi access token. Request body:\n- `grant_type`: must be `urn:ietf:params:oauth:grant-type:token-exchange`\n- `audience`: a URN identifying the target org (e.g., `urn:pulumi:org:{ORG_NAME}`)\n- `subject_token`: the OIDC identity token from the external provider\n- `subject_token_type`: must be `urn:ietf:params:oauth:token-type:id_token`\n- `requested_token_type`: one of `urn:pulumi:token-type:access_token:organization`, `...team`, `...personal`, or `...runner`\n- `scope` *(optional)*: depends on the requested token type. For `organization`, must be empty or `admin`. For `team`, must be `team:TEAM_NAME`. For `personal`, must be `user:USER_LOGIN`. For `runner`, must be `runner:RUNNER_NAME`.\n- `expiration` *(optional)*: token lifetime in seconds.\n\n**Refresh token** (RFC 6749 §6). Exchanges a Pulumi-issued refresh token for a short-lived on-behalf-of access token bound to the user the refresh token resolves to. Request body:\n- `grant_type`: must be `refresh_token`\n- `refresh_token`: the refresh-token value previously issued by Pulumi.\n\nBoth grants return the same response shape: `access_token`, `issued_token_type`, `token_type`, `expires_in`, `scope`, and `refresh_token`.",
         "operationId": "Token",
         "requestBody": {
           "content": {
@@ -33823,7 +38808,8 @@
         },
         "summary": "Token",
         "tags": [
-          "Miscellaneous"
+          "Miscellaneous",
+          "OAuthTokenExchange"
         ]
       }
     },
@@ -33962,7 +38948,8 @@
         },
         "summary": "ListOrgAgentPool",
         "tags": [
-          "Workflows"
+          "Workflows",
+          "DeploymentRunners"
         ]
       },
       "post": {
@@ -34009,7 +38996,8 @@
         },
         "summary": "CreateOrgAgentPool",
         "tags": [
-          "Workflows"
+          "Workflows",
+          "DeploymentRunners"
         ]
       }
     },
@@ -34061,7 +39049,8 @@
         },
         "summary": "DeleteOrgAgentPool",
         "tags": [
-          "Workflows"
+          "Workflows",
+          "DeploymentRunners"
         ]
       },
       "get": {
@@ -34107,7 +39096,8 @@
         },
         "summary": "GetAgentPool",
         "tags": [
-          "Workflows"
+          "Workflows",
+          "DeploymentRunners"
         ]
       },
       "patch": {
@@ -34163,477 +39153,14 @@
         },
         "summary": "PatchOrgAgentPool",
         "tags": [
-          "Workflows"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/ai/conversations": {
-      "get": {
-        "description": "Lists all Pulumi Copilot conversations across an entire organization.",
-        "operationId": "ListOrgConversations",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page number for pagination",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of results per page",
-            "in": "query",
-            "name": "pageSize",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListConversationsResponse"
-                }
-              }
-            },
-            "description": "OK"
-          }
-        },
-        "summary": "ListOrgConversations",
-        "tags": [
-          "AI"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/ai/conversations/{userLogin}": {
-      "get": {
-        "description": "Lists all Pulumi Copilot conversations for a specific user within an organization.",
-        "operationId": "ListConversations",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page number for pagination",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of results per page",
-            "in": "query",
-            "name": "pageSize",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListConversationsResponse"
-                }
-              }
-            },
-            "description": "OK"
-          }
-        },
-        "summary": "ListConversations",
-        "tags": [
-          "AI"
-        ]
-      },
-      "post": {
-        "description": "Creates a new Pulumi Copilot conversation for the specified user.",
-        "operationId": "CreateConversation",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateConversationRequest"
-              }
-            }
-          },
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "409": {
-            "description": "conversation id already registered"
-          }
-        },
-        "summary": "CreateConversation",
-        "tags": [
-          "AI"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/ai/conversations/{userLogin}/{conversationID}": {
-      "get": {
-        "description": "Retrieves the details and messages of a Pulumi Copilot conversation.",
-        "operationId": "GetConversation",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The unique identifier of the Pulumi Copilot conversation",
-            "in": "path",
-            "name": "conversationID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page number for pagination",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of results per page",
-            "in": "query",
-            "name": "pageSize",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetConversationResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "404": {
-            "description": "conversation"
-          }
-        },
-        "summary": "GetConversation",
-        "tags": [
-          "AI"
-        ]
-      },
-      "patch": {
-        "description": "Updates properties of an existing Pulumi Copilot conversation.",
-        "operationId": "PatchConversation",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The unique identifier of the Pulumi Copilot conversation",
-            "in": "path",
-            "name": "conversationID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PatchConversationRequest"
-              }
-            }
-          },
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "404": {
-            "description": "conversation"
-          }
-        },
-        "summary": "PatchConversation",
-        "tags": [
-          "AI"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/ai/conversations/{userLogin}/{conversationID}/feedback": {
-      "post": {
-        "description": "Submits user feedback on a Pulumi Copilot conversation.",
-        "operationId": "SubmitFeedback",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The unique identifier of the Pulumi Copilot conversation",
-            "in": "path",
-            "name": "conversationID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FeedbackRequest"
-              }
-            }
-          },
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "invalid feedbackKind. Only 'thumbsup' or 'thumbsdown' are allowed."
-          }
-        },
-        "summary": "SubmitFeedback",
-        "tags": [
-          "AI"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/ai/conversations/{userLogin}/{conversationID}/messages": {
-      "post": {
-        "description": "Appends a new message to an existing Pulumi Copilot conversation.",
-        "operationId": "AppendMessageToConversation",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The unique identifier of the Pulumi Copilot conversation",
-            "in": "path",
-            "name": "conversationID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AppendMessageToConversationRequest"
-              }
-            }
-          },
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Invalid AI role. Only 'user' or 'assistant' are allowed."
-          },
-          "404": {
-            "description": "conversation"
-          }
-        },
-        "summary": "AppendMessageToConversation",
-        "tags": [
-          "AI"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/ai/conversations/{userLogin}/{conversationID}/programs/{programID}.zip": {
-      "get": {
-        "description": "Fetches a template program as a zip file.",
-        "operationId": "FetchProgram",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The user login name",
-            "in": "path",
-            "name": "userLogin",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The unique identifier of the Pulumi Copilot conversation",
-            "in": "path",
-            "name": "conversationID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The identifier of the generated template program to download",
-            "in": "path",
-            "name": "programID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "404": {
-            "description": "conversation or program"
-          }
-        },
-        "summary": "FetchProgram",
-        "tags": [
-          "AI"
+          "Workflows",
+          "DeploymentRunners"
         ]
       }
     },
     "/api/orgs/{orgName}/auditlogs": {
       "get": {
-        "description": "ListAuditLogEventsHandler is the handler for /orgs/{orgName}/auditlogs.\nLists audit log events by organization and user. Either continuationToken or\nstartTime is required as query params.\nuserFilter query param optionally allows for filtering by user.",
+        "description": "Lists audit log events for an organization. Either continuationToken or startTime is required. Supports filtering by event type and user.",
         "operationId": "ListAuditLogEventsHandlerV1",
         "parameters": [
           {
@@ -34716,13 +39243,14 @@
         },
         "summary": "ListAuditLogEventsHandlerV1",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
     "/api/orgs/{orgName}/auditlogs/export": {
       "get": {
-        "description": "Exports audit log events for an organization in a downloadable format. Audit logs provide an immutable record of all user activity within the organization, including stack operations, member changes, and policy modifications. Results can be filtered by time range, event type, and user. Supported export formats are CSV and CEF (Common Event Format for SIEM integration). Pagination is supported via the continuationToken parameter. Note: In V1, startTime specifies the upper bound of the query range. Use the V2 endpoint for more intuitive time range semantics.",
+        "description": "Exports audit log events for an organization in a downloadable format. Audit logs provide an immutable record of all user activity within the organization, including stack operations, member changes, and policy modifications. Results can be filtered by time range, event type, and user. Supported export formats are CSV and CEF (Common Event Format for SIEM integration). Pagination is supported via the continuationToken parameter.\n\n**Important:** This endpoint differs from other API endpoints:\n- The response is always **gzip compressed**. Use `--compressed` with curl or handle gzip decompression in your client.\n- The `Content-Type: application/json` response header is omitted.\n\nNote: In V1, startTime specifies the upper bound of the query range. Use the V2 endpoint for more intuitive time range semantics.",
         "operationId": "ExportAuditLogEventsHandlerV1",
         "parameters": [
           {
@@ -34805,7 +39333,8 @@
         },
         "summary": "ExportAuditLogEventsHandlerV1",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
@@ -34834,7 +39363,8 @@
         },
         "summary": "DeleteAuditLogExportConfiguration",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       },
       "get": {
@@ -34868,7 +39398,8 @@
         },
         "summary": "GetAuditLogExportConfiguration",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       },
       "post": {
@@ -34905,7 +39436,8 @@
         },
         "summary": "UpdateAuditLogExportConfiguration",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
@@ -34953,7 +39485,8 @@
         },
         "summary": "ForceAuditLogExport",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
@@ -34999,7 +39532,8 @@
         },
         "summary": "TestAuditLogExportConfiguration",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
@@ -35032,13 +39566,14 @@
         },
         "summary": "GetAuditLogsReaderKind",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
     "/api/orgs/{orgName}/auditlogs/v2": {
       "get": {
-        "description": "ListAuditLogEventsHandler is the V2 handler for /orgs/{orgName}/auditlogs\nand lists audit log events by organization and user.\n\nThis API differs from its V1 cousin in the following ways:\n  - `startTime` now specifies the lower bound, rather than the upper bound, of the query range;\n  - `endTime` is now supported to specify the upper bound;\n  - Filtering by audit log event types are now partially supported for self-hosted.\n\nWe maintain the V1 version for backwards compatibility.",
+        "description": "Lists audit log events for an organization. Uses startTime as the lower bound and endTime as the upper bound of the query range. Supports filtering by event type and user.",
         "operationId": "ListAuditLogEventsHandlerV2",
         "parameters": [
           {
@@ -35121,13 +39656,14 @@
         },
         "summary": "ListAuditLogEventsHandlerV2",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
     "/api/orgs/{orgName}/auditlogs/v2/export": {
       "get": {
-        "description": "ExportAuditLogEventsHandler is the V2 handler exporting audit logs in a downloadable format.\nThis API differs from its V1 cousin in the following ways:\n  - `startTime` now specifies the lower bound, rather than the upper bound, of the query range;\n  - `endTime` is now supported to specify the upper bound;\n\nWe maintain the V1 version for backwards compatibility.",
+        "description": "Exports audit log events in a downloadable format (CSV or CEF). Supports filtering by time range using startTime (lower bound) and endTime (upper bound), as well as filtering by event type and user.",
         "operationId": "ExportAuditLogEventsHandlerV2",
         "parameters": [
           {
@@ -35210,7 +39746,8 @@
         },
         "summary": "ExportAuditLogEventsHandlerV2",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AuditLogs"
         ]
       }
     },
@@ -35255,13 +39792,14 @@
         },
         "summary": "GetAuthPolicy",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       }
     },
     "/api/orgs/{orgName}/auth/policies/{policyId}": {
       "patch": {
-        "description": "Updates an authentication policy for an organization. Authentication policies define rules for how OIDC tokens are validated and what access they grant, including claim mappings, trust conditions, and role assignments. The policy definition cannot be empty.",
+        "description": "Updates an authentication policy for an organization. Authentication policies define rules for how OIDC tokens are validated and what access they grant, including claim mappings, trust conditions, and role assignments. The policy definition cannot be empty.\n\nThe request body contains a `policies` array where each policy object includes:\n- `decision`: `allow` or `deny`\n- `tokenType`: `organization`, `team`, `personal`, or `runner`\n- `teamName`: required when tokenType is `team`\n- `userLogin`: required when tokenType is `personal`\n- `runnerID`: required when tokenType is `runner`\n- `authorizedPermissions`: array of permissions (only `admin` is supported for organization tokens)\n- `rules`: object defining claim-matching rules for the token\n\nFor more information about authorization rules, refer to the [OIDC authorization policies documentation](https://www.pulumi.com/docs/pulumi-cloud/access-management/oidc/client/#configure-the-authorization-policies).",
         "operationId": "UpdateAuthPolicy",
         "parameters": [
           {
@@ -35309,39 +39847,6 @@
           }
         },
         "summary": "UpdateAuthPolicy",
-        "tags": [
-          "Organizations"
-        ]
-      }
-    },
-    "/api/orgs/{orgName}/billing/managers": {
-      "get": {
-        "description": "ListBillingManagers lists the billing managers of an organization. This will always\nreturn no results for Team Pro and Team Per Stack, which don't have billing managers.\n\nCurrently not a paginated request",
-        "operationId": "ListBillingManagers",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOrganizationMembersResponse"
-                }
-              }
-            },
-            "description": "OK"
-          }
-        },
-        "summary": "ListBillingManagers",
         "tags": [
           "Organizations"
         ]
@@ -35725,7 +40230,7 @@
     },
     "/api/orgs/{orgName}/deployments/metadata": {
       "get": {
-        "description": "Returns metadata about the organization's Pulumi Deployments state. The response includes the overall pause status, a list of individually paused stacks, the configured concurrency limit (maximum number of concurrent deployments), and deployment counts broken down by status (notStarted, accepted, running, failed, succeeded, skipped, and total). This endpoint is useful for monitoring deployment health and capacity across an organization.",
+        "description": "Returns metadata about the organization's Pulumi Deployments state. The response includes the overall pause status, a list of individually paused stacks (as stack references like `project/stack`), the configured concurrency limit (maximum number of concurrent deployments), and deployment counts broken down by status (`notStarted`, `accepted`, `running`, `failed`, `succeeded`, `skipped`, and `total`). This endpoint is useful for monitoring deployment health and capacity across an organization.",
         "operationId": "OrgDeploymentsMetadata",
         "parameters": [
           {
@@ -35823,15 +40328,34 @@
             }
           },
           {
-            "description": "Time granularity for the summary (e.g. 'daily', 'hourly')",
+            "description": "Time granularity for the summary. Hourly granularity is limited to a 2-day lookback.",
             "in": "query",
             "name": "granularity",
+            "required": true,
             "schema": {
-              "type": "string"
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "UsageSummaryTimeUnit represents the granularity of RUM summary data.",
+                "enumFieldComments": [
+                  "Aggregate yearly.",
+                  "Aggregate monthly.",
+                  "Aggregate weekly.",
+                  "Aggregate daily.",
+                  "Aggregate hourly."
+                ],
+                "enumTypeName": "UsageSummaryTimeUnit"
+              }
             }
           },
           {
-            "description": "Number of days to look back from the current date",
+            "description": "Number of days to look back from the current date. Must be positive; when granularity is 'hourly' the value must not exceed 2. Mutually exclusive with lookbackStart; exactly one must be provided.",
             "in": "query",
             "name": "lookbackDays",
             "schema": {
@@ -35840,7 +40364,7 @@
             }
           },
           {
-            "description": "Start of the lookback period (Unix timestamp)",
+            "description": "Start of the lookback period as a Unix timestamp (seconds since epoch). Must be positive, in the past, and within the last year. Mutually exclusive with lookbackDays; exactly one must be provided.",
             "in": "query",
             "name": "lookbackStart",
             "schema": {
@@ -35936,15 +40460,34 @@
             }
           },
           {
-            "description": "Time granularity for aggregation (e.g., 'hourly', 'daily', 'monthly')",
+            "description": "Time granularity for aggregation. Hourly granularity is limited to a 2-day lookback.",
             "in": "query",
             "name": "granularity",
+            "required": true,
             "schema": {
-              "type": "string"
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "UsageSummaryTimeUnit represents the granularity of RUM summary data.",
+                "enumFieldComments": [
+                  "Aggregate yearly.",
+                  "Aggregate monthly.",
+                  "Aggregate weekly.",
+                  "Aggregate daily.",
+                  "Aggregate hourly."
+                ],
+                "enumTypeName": "UsageSummaryTimeUnit"
+              }
             }
           },
           {
-            "description": "Number of days to look back from the current time or lookbackStart",
+            "description": "Number of days to look back from the current time. Must be positive; when granularity is 'hourly' the value must not exceed 2. Mutually exclusive with lookbackStart; exactly one must be provided.",
             "in": "query",
             "name": "lookbackDays",
             "schema": {
@@ -35953,7 +40496,7 @@
             }
           },
           {
-            "description": "Unix timestamp for the start of the lookback period (defaults to current time if omitted)",
+            "description": "Unix timestamp (seconds since epoch) for the start of the lookback period. Must be positive, in the past, and within the last year. Mutually exclusive with lookbackDays; exactly one must be provided.",
             "in": "query",
             "name": "lookbackStart",
             "schema": {
@@ -35979,14 +40522,15 @@
         },
         "summary": "GetUsageSummaryDiscoveredResourceHours",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "ResourcesUnderManagement"
         ]
       }
     },
     "/api/orgs/{orgName}/hooks": {
       "get": {
         "description": "Returns all webhooks configured at the organization level. Each webhook in the response includes its name, destination URL, format (generic JSON, Slack, or Microsoft Teams), active status, and subscribed event filters. Organization-level webhooks can fire on stack lifecycle events, deployment events, drift detection events, and policy violation events.",
-        "operationId": "ListWebhooks_orgs",
+        "operationId": "ListOrganizationWebhooks",
         "parameters": [
           {
             "description": "The organization name",
@@ -36013,14 +40557,15 @@
             "description": "successful operation"
           }
         },
-        "summary": "ListWebhooks",
+        "summary": "ListOrganizationWebhooks",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       },
       "post": {
-        "description": "Creates a new webhook for an organization to notify external services when events occur. Webhooks can be configured to fire on stack events (created, deleted, update succeeded/failed), deployment events (queued, started, succeeded, failed), drift detection events, and policy violation events (mandatory, advisory). Supported formats include generic JSON webhooks, Slack incoming webhooks, Microsoft Teams webhooks, and deployment triggers for dependent stacks. An optional shared secret enables HMAC-SHA256 signature verification via the Pulumi-Webhook-Signature header, allowing recipients to authenticate that deliveries originate from Pulumi Cloud.",
-        "operationId": "CreateWebhook_orgs",
+        "description": "Creates a new webhook for an organization to notify external services when events occur. Webhooks can be configured to fire on stack events (created, deleted, update succeeded/failed), deployment events (queued, started, succeeded, failed), drift detection events, and policy violation events (mandatory, advisory).\n\nThe `format` field accepts: `raw` (default), `slack`, `ms_teams`, or `pulumi_deployments`.\n\nThe `filters` field accepts a list of event types to subscribe to. See the [webhook event filtering documentation](https://www.pulumi.com/docs/pulumi-cloud/webhooks/#event-filtering) for available filters.\n\nThe optional `secret` field sets the HMAC key for signature verification via the `Pulumi-Webhook-Signature` header. See the [webhook headers documentation](https://www.pulumi.com/docs/pulumi-cloud/webhooks/#headers) for details.",
+        "operationId": "CreateOrganizationWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -36060,16 +40605,17 @@
             "description": "Webhook with this name already exists"
           }
         },
-        "summary": "CreateWebhook",
+        "summary": "CreateOrganizationWebhook",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       }
     },
     "/api/orgs/{orgName}/hooks/{hookName}": {
       "delete": {
         "description": "Permanently deletes an organization-level webhook. The webhook will no longer receive event notifications for stack updates, deployments, drift detection, or policy violations. This action cannot be undone.",
-        "operationId": "DeleteWebhook_orgs",
+        "operationId": "DeleteOrganizationWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -36095,14 +40641,15 @@
             "description": "No Content"
           }
         },
-        "summary": "DeleteWebhook",
+        "summary": "DeleteOrganizationWebhook",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       },
       "get": {
         "description": "Returns the configuration of a specific organization-level webhook, including its name, destination URL, format (generic JSON, Slack, or Microsoft Teams), active status, event filter subscriptions, and whether a shared secret is configured for HMAC signature verification.",
-        "operationId": "GetWebhook_orgs",
+        "operationId": "GetOrganizationWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -36138,14 +40685,15 @@
             "description": "Webhook"
           }
         },
-        "summary": "GetWebhook",
+        "summary": "GetOrganizationWebhook",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       },
       "patch": {
         "description": "Updates an existing organization-level webhook's configuration, including its destination URL, format, active status, event filter subscriptions, and shared secret. The 'pulumi_deployments' format can only be used on stack or environment webhooks, not organization-level ones.",
-        "operationId": "UpdateWebhook_orgs",
+        "operationId": "UpdateOrganizationWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -36194,16 +40742,17 @@
             "description": "Webhook"
           }
         },
-        "summary": "UpdateWebhook",
+        "summary": "UpdateOrganizationWebhook",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       }
     },
     "/api/orgs/{orgName}/hooks/{hookName}/deliveries": {
       "get": {
         "description": "Returns the recent delivery history for a specific webhook, including the HTTP status code, response time, request payload, and delivery timestamp for each attempt. This allows monitoring webhook health and diagnosing delivery failures. Each delivery includes a unique Pulumi-Webhook-ID.",
-        "operationId": "GetWebhookDeliveries_orgs",
+        "operationId": "GetOrganizationWebhookDeliveries",
         "parameters": [
           {
             "description": "The organization name",
@@ -36239,16 +40788,17 @@
             "description": "successful operation"
           }
         },
-        "summary": "GetWebhookDeliveries",
+        "summary": "GetOrganizationWebhookDeliveries",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       }
     },
     "/api/orgs/{orgName}/hooks/{hookName}/deliveries/{event}/redeliver": {
       "post": {
-        "description": "RedeliverWebhookEvent will trigger the Pulumi Service to redeliver\na specific event to a webhook. For example, to resend an event that the\nhook failed to process the first time.",
-        "operationId": "RedeliverWebhookEvent_orgs",
+        "description": "Triggers the Pulumi Service to redeliver\na specific event to a webhook. For example, to resend an event that the\nhook failed to process the first time.",
+        "operationId": "RedeliverOrganizationWebhookEvent",
         "parameters": [
           {
             "description": "The organization name",
@@ -36293,16 +40843,17 @@
             "description": "Webhook"
           }
         },
-        "summary": "RedeliverWebhookEvent",
+        "summary": "RedeliverOrganizationWebhookEvent",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       }
     },
     "/api/orgs/{orgName}/hooks/{hookName}/ping": {
       "post": {
-        "description": "PingWebhook sends a test ping to a webhook to validate it's working.\nThis function bypasses the message queue machinery and issues the request directly to the webhook.",
-        "operationId": "PingWebhook_orgs",
+        "description": "Sends a test ping to an organization webhook to validate that it is working.\nThis function bypasses the message queue machinery and issues the request directly to the webhook.",
+        "operationId": "PingOrganizationWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -36338,15 +40889,16 @@
             "description": "Webhook"
           }
         },
-        "summary": "PingWebhook",
+        "summary": "PingOrganizationWebhook",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Webhooks"
         ]
       }
     },
     "/api/orgs/{orgName}/insights-scans/summary": {
       "get": {
-        "description": "GetUsageSummaryInsightsScans handles request to fetch the summary\nof insights scans minutes for an organization.",
+        "description": "Returns a summary of Insights scan usage for an organization, grouped by the specified time granularity.",
         "operationId": "GetUsageSummaryInsightsScans",
         "parameters": [
           {
@@ -36359,11 +40911,30 @@
             }
           },
           {
-            "description": "Time granularity for grouping usage data. Valid values: 'hourly', 'daily', 'weekly', 'monthly', 'yearly'. Hourly granularity is limited to a 2-day lookback.",
+            "description": "Time granularity for grouping usage data. Hourly granularity is limited to a 2-day lookback.",
             "in": "query",
             "name": "granularity",
+            "required": true,
             "schema": {
-              "type": "string"
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "UsageSummaryTimeUnit represents the granularity of RUM summary data.",
+                "enumFieldComments": [
+                  "Aggregate yearly.",
+                  "Aggregate monthly.",
+                  "Aggregate weekly.",
+                  "Aggregate daily.",
+                  "Aggregate hourly."
+                ],
+                "enumTypeName": "UsageSummaryTimeUnit"
+              }
             }
           },
           {
@@ -36402,7 +40973,349 @@
         },
         "summary": "GetUsageSummaryInsightsScans",
         "tags": [
-          "Insights"
+          "Insights",
+          "InsightsAccounts"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/invites": {
+      "get": {
+        "description": "Lists all pending invitations for an organization. Pending invitations count toward the organization's seat limit, since they reserve capacity for the users who eventually accept. Each entry includes the invite ID, recipient email, role assignment, sender, and the timestamp when it was last sent.",
+        "operationId": "ListOrgInvites",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOrganizationInvitesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ListOrgInvites",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/invites/batch": {
+      "post": {
+        "description": "Creates multiple organization invitations in a single request and sends email notifications to each invitee. Each invitation includes a role assignment (admin or member) and optional team assignments. Pending invitations count toward the organization's seat limit. The request body size is limited to prevent abuse.",
+        "operationId": "BatchCreateOrgInviteEmail",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchCreateOrganizationInviteRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchCreateOrganizationInviteResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid email address."
+          }
+        },
+        "summary": "BatchCreateOrgInviteEmail",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/invites/link": {
+      "post": {
+        "description": "Generates a new invite URL to join an organization, intended to be shared via copy/paste. Does not send out an email and does not require an email address in the request. Anyone with a Pulumi account who knows the resulting URL can accept the invitation, so share the link only with the intended recipient.",
+        "operationId": "CreateOrgInviteLink",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrganizationInviteRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrganizationInviteResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "CreateOrgInviteLink",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/invites/unverified/batch": {
+      "post": {
+        "description": "Creates multiple organization invitations for email addresses that may not yet have Pulumi accounts. Unlike the standard batch invite, this does not require the invitees to have verified email addresses. The invitee will be prompted to create an account when they accept the invitation.",
+        "operationId": "BatchCreateOrgUnverifiedInviteEmail",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchCreateOrganizationInviteRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchCreateOrganizationInviteResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid email address."
+          }
+        },
+        "summary": "BatchCreateOrgUnverifiedInviteEmail",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/invites/{inviteID}": {
+      "delete": {
+        "description": "Cancels a pending organization invitation, reclaiming the seat it reserves in the organization. Pending invitations count toward the organization's seat limit, so canceling frees up capacity for new invitations or members. Returns 404 if the invite does not exist.",
+        "operationId": "CancelOrgInvite",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The invite identifier",
+            "in": "path",
+            "name": "inviteID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Invite"
+          }
+        },
+        "summary": "CancelOrgInvite",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      },
+      "get": {
+        "description": "Validates the organization name and invite ID from the URL and, if they correspond to an active invitation, returns basic organization metadata. This provides a reasonably secure way to share organization metadata with a non-member without making it available to everyone, since the caller must know both the organization login and the invite ID. Returns 404 if the invite has already been accepted or canceled.",
+        "operationId": "GetOrgInvite",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The invite identifier",
+            "in": "path",
+            "name": "inviteID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationSummaryWithRole"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Invite"
+          }
+        },
+        "summary": "GetOrgInvite",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      },
+      "patch": {
+        "description": "Accepts an organization invitation. The authenticated user making the request will be added as a member of the organization. IMPORTANT: if the URL used to accept the invite is disclosed, anybody else with a Pulumi account can accept/claim it. Returns 409 if the invite is not in the 'invited' state (already accepted or canceled).",
+        "operationId": "AcceptOrgInvite",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The invite identifier",
+            "in": "path",
+            "name": "inviteID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "409": {
+            "description": "Invite is not in the 'invited' state"
+          }
+        },
+        "summary": "AcceptOrgInvite",
+        "tags": [
+          "Organizations",
+          "Invites"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/invites/{inviteID}/resend": {
+      "post": {
+        "description": "Resends an existing organization invitation. Sends another invitation email and updates the 'sent' timestamp to the current time. The sender of the resent invite may differ from the original sender. Returns 404 if the invite has already been accepted or canceled.",
+        "operationId": "ResendOrgInvite",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The invite identifier",
+            "in": "path",
+            "name": "inviteID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResendOrganizationInviteRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Invite"
+          }
+        },
+        "summary": "ResendOrgInvite",
+        "tags": [
+          "Organizations",
+          "Invites"
         ]
       }
     },
@@ -36499,7 +41412,7 @@
         ]
       },
       "patch": {
-        "description": "Modifies a user's role or permissions within an organization. The request body can update the member's role (admin or member) or assign a custom role ID. Admin members have full control over the organization, while regular members have access based on their team memberships and stack permissions.",
+        "description": "Modifies a user's role within an organization. Set `role` to assign a built-in role (`member`, `admin`, or `billingManager`), or set `fgaRoleId` to assign a custom role. If both are provided, `fgaRoleId` takes precedence.",
         "operationId": "UpdateOrganizationMember",
         "parameters": [
           {
@@ -36548,7 +41461,7 @@
         ]
       },
       "post": {
-        "description": "Adds an existing Pulumi user to an organization with a specified role. The request body must include the role to assign, such as 'admin' or 'member'. Admin members have full control over the organization including member management, billing, and settings, while regular members have access based on their team memberships and stack permissions. Returns the newly created organization member record. Returns 409 if the user is already a member of the organization.",
+        "description": "Adds an existing Pulumi user to an organization with a built-in role. **Important:** The user must have already signed up for a Pulumi account before they can be added to an organization.\n\nThis endpoint only assigns built-in roles. To onboard a user with a custom role, use the organization invite flow (`BatchCreateOrgInviteEmail`) and set `roleId` on the invite — the custom role is applied when the user accepts. Alternatively, add the user here with a built-in role and then call `UpdateOrganizationMember` with `fgaRoleId` to reassign.\n\nReturns the newly created organization member record. Returns 409 if the user is already a member of the organization.",
         "operationId": "AddOrganizationMember",
         "parameters": [
           {
@@ -36609,7 +41522,7 @@
     },
     "/api/orgs/{orgName}/members/{userLogin}/set-admin": {
       "post": {
-        "description": "SetSoleOrganizationAdmin is specific to scenario you can get into with our Team Starter or Team Growth subscription plan:\nTeam Starter or Team Growth organizations can only have one administrator. Which means that you cannot use the\nUpdateOrganizationMemberHandler to \"promote\" a member to admin. (Since you would need to simultaneously \"demote\"\nthe current administrator to a normal member.)\n\nThis function will fail if called for a non-Team Starter or Team Growth subscription",
+        "description": "Promotes a member to administrator on organizations that are limited to a single admin. This endpoint is only valid for Team subscriptions (Team Starter and Team Growth) — it returns 400 on any other plan. On these plans, `UpdateOrganizationMember` cannot promote a member to admin, because doing so would require simultaneously demoting the current admin. This endpoint performs both changes atomically: the caller (who must be the current sole admin) is demoted to member and the target user is promoted to admin.\n\n**Note:** This endpoint operates on built-in roles only and does not integrate with custom roles.",
         "operationId": "SetSoleOrganizationAdmin",
         "parameters": [
           {
@@ -36648,6 +41561,51 @@
         ]
       }
     },
+    "/api/orgs/{orgName}/members/{user}/teams": {
+      "get": {
+        "description": "Lists the teams a user belongs to within an organization. Returns display names for Pulumi-managed teams and teams synced from a backend identity provider.",
+        "operationId": "GetOrganizationMemberTeams",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The user's login name",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetOrganizationMemberTeamsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          }
+        },
+        "summary": "GetOrganizationMemberTeams",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
     "/api/orgs/{orgName}/metadata": {
       "get": {
         "description": "GetOrganizationMetadata returns metadata about the given organization. This is\ndesigned to be an inexpensive call.",
@@ -36681,6 +41639,235 @@
         ]
       }
     },
+    "/api/orgs/{orgName}/neo/token-budget": {
+      "get": {
+        "description": "Returns the current Neo-token allowance and consumption for an organization. Returns 404 when no Neo-token cap applies to this organization.",
+        "operationId": "GetOrgNeoTokenBudget",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgNeoTokenBudget"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "No Neo-token cap applies to this organization"
+          }
+        },
+        "summary": "GetOrgNeoTokenBudget",
+        "tags": [
+          "Neo"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/neo/tokens/summary": {
+      "get": {
+        "description": "Returns the summary of Neo AI agent token usage for an organization, aggregated by the specified time granularity over a given lookback period.",
+        "operationId": "GetUsageSummaryNeoTokens",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time granularity for aggregation",
+            "in": "query",
+            "name": "granularity",
+            "required": true,
+            "schema": {
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "UsageSummaryTimeUnit represents the granularity of RUM summary data.",
+                "enumFieldComments": [
+                  "Aggregate yearly.",
+                  "Aggregate monthly.",
+                  "Aggregate weekly.",
+                  "Aggregate daily.",
+                  "Aggregate hourly."
+                ],
+                "enumTypeName": "UsageSummaryTimeUnit"
+              }
+            }
+          },
+          {
+            "description": "When true, returns usage broken down by tag keys (TaskID, Feature) from the tag-keyed aggregation table. Days with no usage are filled with zero-value entries. The response includes tagKeys listing the available breakdown keys.",
+            "in": "query",
+            "name": "includeTagBreakdown",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Number of days to look back from the current time or lookbackStart",
+            "in": "query",
+            "name": "lookbackDays",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Unix timestamp for the start of the lookback period (defaults to current time if omitted)",
+            "in": "query",
+            "name": "lookbackStart",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetResourceCountSummaryResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "GetUsageSummaryNeoTokens",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
+    "/api/orgs/{orgName}/neo/usage-cap": {
+      "delete": {
+        "description": "Removes the monthly Neo usage cap for an organization, returning it to the uncapped default. Idempotent — deleting when no cap is set returns 204.",
+        "operationId": "DeleteNeoUsageCap",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "DeleteNeoUsageCap",
+        "tags": [
+          "Neo"
+        ]
+      },
+      "get": {
+        "description": "Returns the org admin-configured monthly Neo usage cap for an organization, or 204 (no content) when no cap is configured (the default). Caps are denominated in cents.",
+        "operationId": "GetNeoUsageCap",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NeoUsageCap"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "204": {
+            "description": "No cap configured for this organization"
+          }
+        },
+        "summary": "GetNeoUsageCap",
+        "tags": [
+          "Neo"
+        ]
+      },
+      "put": {
+        "description": "Creates or replaces the monthly Neo usage cap for an organization. The cap must be at least $10/month. To remove the cap, call DeleteNeoUsageCap.",
+        "operationId": "UpdateNeoUsageCap",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNeoUsageCapRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NeoUsageCap"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid cap configuration"
+          }
+        },
+        "summary": "UpdateNeoUsageCap",
+        "tags": [
+          "Neo"
+        ]
+      }
+    },
     "/api/orgs/{orgName}/oidc/issuers": {
       "get": {
         "description": "Returns all OIDC issuer registrations for an organization. OIDC issuer registrations establish trust relationships with external identity providers (such as AWS, Azure, Google Cloud, or GitHub Actions) to enable token exchange for temporary Pulumi Cloud credentials. This eliminates the need for long-lived access tokens in CI/CD pipelines and deployment automation.",
@@ -36710,7 +41897,8 @@
         },
         "summary": "List",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       },
       "post": {
@@ -36754,7 +41942,8 @@
         },
         "summary": "RegisterOidcIssuer",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       }
     },
@@ -36792,7 +41981,8 @@
         },
         "summary": "DeleteOidcIssuer",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       },
       "get": {
@@ -36835,7 +42025,8 @@
         },
         "summary": "GetOidcIssuer",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       },
       "patch": {
@@ -36891,7 +42082,8 @@
         },
         "summary": "UpdateOidcIssuer",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       }
     },
@@ -36939,7 +42131,8 @@
         },
         "summary": "RegenerateThumbprints",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "OidcIssuers"
         ]
       }
     },
@@ -37047,7 +42240,8 @@
         },
         "summary": "ListPolicyGroups",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       },
       "post": {
@@ -37090,7 +42284,8 @@
         },
         "summary": "NewPolicyGroup",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       }
     },
@@ -37126,7 +42321,8 @@
         },
         "summary": "GetPolicyGroupMetadata",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       }
     },
@@ -37167,7 +42363,8 @@
         },
         "summary": "DeletePolicyGroup",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       },
       "get": {
@@ -37210,11 +42407,12 @@
         },
         "summary": "GetPolicyGroup",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       },
       "patch": {
-        "description": "Updates a Policy Group's configuration, including its name, the stacks or cloud accounts assigned to it, and the Policy Packs applied with their enforcement levels (advisory, mandatory, or disabled). This allows adjusting which policies are enforced on which infrastructure resources and at what severity.",
+        "description": "Updates a Policy Group's configuration. This multi-purpose endpoint supports several operations in a single request via different body fields:\n\n- `newName`: rename the policy group\n- `addStack` / `removeStack`: add or remove stacks (with `name` and `routingProject` fields)\n- `addPolicyPack` / `removePolicyPack`: add or remove policy packs (with `name`, `version`, `versionTag`, and optional `config`)\n- `addInsightsAccount` / `removeInsightsAccount`: add or remove Insights accounts\n\nEnforcement levels for policy packs are `advisory`, `mandatory`, or `disabled`.",
         "operationId": "UpdatePolicyGroup",
         "parameters": [
           {
@@ -37259,7 +42457,8 @@
         },
         "summary": "UpdatePolicyGroup",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       }
     },
@@ -37313,7 +42512,8 @@
         },
         "summary": "BatchUpdatePolicyGroup",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyGroups"
         ]
       }
     },
@@ -37357,7 +42557,8 @@
         },
         "summary": "ListPolicyPacks",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       },
       "post": {
@@ -37401,7 +42602,8 @@
         },
         "summary": "CreatePolicyPack",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       }
     },
@@ -37442,7 +42644,8 @@
         },
         "summary": "DeletePolicyPack",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       }
     },
@@ -37495,7 +42698,8 @@
         },
         "summary": "DeletePolicyPackVersion",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       },
       "get": {
@@ -37550,7 +42754,8 @@
         },
         "summary": "GetPolicyPack",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       }
     },
@@ -37600,7 +42805,8 @@
         },
         "summary": "CompletePolicyPack",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       }
     },
@@ -37657,7 +42863,8 @@
         },
         "summary": "GetPolicyPackConfigSchema",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       }
     },
@@ -37706,7 +42913,8 @@
         },
         "summary": "GetPolicyComplianceResults",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -37722,6 +42930,14 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "If true, return closed issues; if false or omitted, return active issues",
+            "in": "query",
+            "name": "closed",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -37755,7 +42971,8 @@
         },
         "summary": "ListPolicyIssues",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -37771,6 +42988,14 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "If true, return closed issues; if false or omitted, return active issues",
+            "in": "query",
+            "name": "closed",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -37804,7 +43029,8 @@
         },
         "summary": "ExportPolicyIssues",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -37820,6 +43046,14 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "If true, return filters for closed issues; if false or omitted, return filters for active issues",
+            "in": "query",
+            "name": "closed",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -37853,7 +43087,8 @@
         },
         "summary": "GetPolicyIssuesFilters",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -37898,11 +43133,12 @@
         },
         "summary": "GetPolicyIssue",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       },
       "patch": {
-        "description": "Updates a policy issue's triage status and other mutable fields. This allows organization members to mark issues as acknowledged, suppressed, or resolved, helping teams track their policy compliance remediation progress.",
+        "description": "Updates a policy issue's triage status and other mutable fields. All body fields are optional — only provide the fields you want to update.\n\n- `status`: `open`, `in_progress`, or `ignored` (`fixed` and `by_design` cannot be set manually)\n- `priority`: `p0`, `p1`, `p2`, `p3`, or `p4`\n- `assignedTo`: username to assign the issue to, or `null` to unassign",
         "operationId": "UpdatePolicyIssue",
         "parameters": [
           {
@@ -37954,7 +43190,8 @@
         },
         "summary": "UpdatePolicyIssue",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -37990,7 +43227,8 @@
         },
         "summary": "GetPolicyResultsMetadata",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -38039,7 +43277,8 @@
         },
         "summary": "ListPoliciesCompliance",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyResults"
         ]
       }
     },
@@ -38076,8 +43315,14 @@
         },
         "summary": "ListPolicyViolationsV2",
         "tags": [
-          "Organizations"
-        ]
+          "Organizations",
+          "PolicyResults"
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListPolicyIssues",
+          "Visibility": "Public"
+        }
       }
     },
     "/api/orgs/{orgName}/registry/policypacks/{policyPackName}": {
@@ -38129,7 +43374,8 @@
         },
         "summary": "GetOrgRegistryPolicyPack",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "PolicyPacks"
         ]
       }
     },
@@ -38148,15 +43394,34 @@
             }
           },
           {
-            "description": "Time granularity for aggregation (e.g., 'hourly', 'daily', 'monthly')",
+            "description": "Time granularity for aggregation. Hourly granularity is limited to a 2-day lookback.",
             "in": "query",
             "name": "granularity",
+            "required": true,
             "schema": {
-              "type": "string"
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "UsageSummaryTimeUnit represents the granularity of RUM summary data.",
+                "enumFieldComments": [
+                  "Aggregate yearly.",
+                  "Aggregate monthly.",
+                  "Aggregate weekly.",
+                  "Aggregate daily.",
+                  "Aggregate hourly."
+                ],
+                "enumTypeName": "UsageSummaryTimeUnit"
+              }
             }
           },
           {
-            "description": "Number of days to look back from the current time or lookbackStart",
+            "description": "Number of days to look back from the current time. Must be positive; when granularity is 'hourly' the value must not exceed 2. Mutually exclusive with lookbackStart; exactly one must be provided.",
             "in": "query",
             "name": "lookbackDays",
             "schema": {
@@ -38165,7 +43430,7 @@
             }
           },
           {
-            "description": "Unix timestamp for the start of the lookback period (defaults to current time if omitted)",
+            "description": "Unix timestamp (seconds since epoch) for the start of the lookback period. Must be positive, in the past, and within the last year. Mutually exclusive with lookbackDays; exactly one must be provided.",
             "in": "query",
             "name": "lookbackStart",
             "schema": {
@@ -38191,7 +43456,8 @@
         },
         "summary": "GetUsageSummaryResourceHours",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "ResourcesUnderManagement"
         ]
       }
     },
@@ -38294,11 +43560,30 @@
             }
           },
           {
-            "description": "Filter roles by their UX purpose (e.g., 'organization', 'team', 'token')",
+            "description": "Filter roles by their UX purpose",
             "in": "query",
             "name": "uxPurpose",
+            "required": true,
             "schema": {
-              "type": "string"
+              "enum": [
+                "role",
+                "role_private",
+                "role_temporary",
+                "policy",
+                "set"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "Categorizes how a permission descriptor is presented in the UI.",
+                "enumFieldNames": [
+                  "Role",
+                  "RolePrivate",
+                  "RoleTemporary",
+                  "Policy",
+                  "Set"
+                ],
+                "enumTypeName": "PermissionDescriptorUXPurpose"
+              }
             }
           }
         ],
@@ -38323,7 +43608,7 @@
         ]
       },
       "post": {
-        "description": "Creates a new custom role for an organization. Custom roles define fine-grained permission sets that can be assigned to organization members and teams, enabling precise access control beyond the built-in admin and member roles. Optionally, an associated policy and role binding can be created alongside the role.",
+        "description": "Creates a new custom role for an organization. Custom roles define fine-grained permission sets that can be assigned to organization members and teams, enabling precise access control beyond the built-in admin and member roles. Optionally, an associated policy and role binding can be created alongside the role. Role definitions are subject to two limits: a permission descriptor group may contain at most 2000 entries (each directly-specified entity counts as one entry), and the total serialized size of the role definition may not exceed 1 MB. Exceeding either limit returns a 400 error. If you need to grant access to more than 2000 individually listed resources, use tag-based (ABAC) rules instead.",
         "operationId": "CreateRole",
         "parameters": [
           {
@@ -38366,7 +43651,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "Invalid role references: referenced role or permission set ID does not exist or is empty"
+            "description": "Invalid request: referenced role or permission set does not exist, permission descriptor exceeds the 2000-entry limit, or role definition exceeds the 1 MB size limit"
           },
           "409": {
             "description": "Role with this name already exists"
@@ -38506,7 +43791,7 @@
         ]
       },
       "patch": {
-        "description": "Updates an existing custom role's name, description, or permission scopes. Changes take effect immediately for all members and teams assigned to the role.",
+        "description": "Updates an existing custom role's name, description, or permission scopes. Changes take effect immediately for all members and teams assigned to the role. The same limits that apply to CreateRole apply here: a permission descriptor group may contain at most 2000 entries, and the total serialized size of the role definition may not exceed 1 MB. Exceeding either limit returns a 400 error.",
         "operationId": "UpdateRole",
         "parameters": [
           {
@@ -38550,7 +43835,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "Invalid role references: referenced role or permission set ID does not exist or is empty"
+            "description": "Invalid request: referenced role or permission set does not exist, permission descriptor exceeds the 2000-entry limit, or role definition exceeds the 1 MB size limit"
           },
           "409": {
             "description": "Role with this name already exists"
@@ -38972,7 +44257,7 @@
     "/api/orgs/{orgName}/search/resources": {
       "get": {
         "deprecated": true,
-        "description": "GetOrgResourceSearchQuery serves resource search results. DEPRECATED: Use GetOrgResourceSearchV2Query instead for improved search functionality.",
+        "description": "Searches for resources within an organization. Deprecated: use GetOrgResourceSearchV2Query for improved search functionality.",
         "operationId": "GetOrgResourceSearchQuery",
         "parameters": [
           {
@@ -39094,8 +44379,14 @@
         },
         "summary": "GetOrgResourceSearchQuery",
         "tags": [
-          "Organizations"
-        ]
+          "Organizations",
+          "ResourceSearch"
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetOrgResourceSearchV2Query",
+          "Visibility": "Public"
+        }
       }
     },
     "/api/orgs/{orgName}/search/resources/dashboard": {
@@ -39133,7 +44424,8 @@
         },
         "summary": "GetResourceDashboardAggregations",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "ResourceSearch"
         ]
       }
     },
@@ -39250,7 +44542,8 @@
         },
         "summary": "ExportOrgResourceSearchQuery",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "DataExport"
         ]
       }
     },
@@ -39303,13 +44596,14 @@
         },
         "summary": "GetNaturalLanguageQuery",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "ResourceSearch"
         ]
       }
     },
     "/api/orgs/{orgName}/search/resourcesv2": {
       "get": {
-        "description": "GetOrgResourceSearchV2Query searches for resources within an organization with advanced filtering, sorting, and pagination capabilities.",
+        "description": "Searches for resources within an organization with advanced filtering, sorting, and pagination capabilities.\n\n**Pagination:** The `page` parameter supports up to 10,000 results. For larger result sets, use the `cursor` parameter instead (Enterprise plans only). Note that pagination is not transactional — result ordering may change if a stack update completes during pagination.\n\n**Sorting:** The `sort` parameter accepts: `created`, `custom`, `delete`, `dependencies`, `id`, `modified`, `module`, `name`, `package`, `parentUrn`, `project`, `protected`, `providerUrn`, `stack`, `type`, `urn`, `managed`, `category`. If omitted, results are sorted by search relevance (or last modified time when no query is provided).\n\n**Properties:** Set `properties=true` to include resource input/output values. Requires a supported subscription — returns 402 if not available.\n\n**Collapse:** Set `collapse=true` to consolidate resources that exist in multiple sources (e.g., both IaC stacks and Insights scans) into a single result.",
         "operationId": "GetOrgResourceSearchV2Query",
         "parameters": [
           {
@@ -39439,7 +44733,8 @@
         },
         "summary": "GetOrgResourceSearchV2Query",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "ResourceSearch"
         ]
       }
     },
@@ -39458,15 +44753,34 @@
             }
           },
           {
-            "description": "Time granularity for aggregation (e.g., 'hourly', 'daily', 'monthly')",
+            "description": "Time granularity for aggregation. Hourly granularity is limited to a 2-day lookback.",
             "in": "query",
             "name": "granularity",
+            "required": true,
             "schema": {
-              "type": "string"
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "UsageSummaryTimeUnit represents the granularity of RUM summary data.",
+                "enumFieldComments": [
+                  "Aggregate yearly.",
+                  "Aggregate monthly.",
+                  "Aggregate weekly.",
+                  "Aggregate daily.",
+                  "Aggregate hourly."
+                ],
+                "enumTypeName": "UsageSummaryTimeUnit"
+              }
             }
           },
           {
-            "description": "Number of days to look back from the current time or lookbackStart",
+            "description": "Number of days to look back from the current time. Must be positive; when granularity is 'hourly' the value must not exceed 2. Mutually exclusive with lookbackStart; exactly one must be provided.",
             "in": "query",
             "name": "lookbackDays",
             "schema": {
@@ -39475,7 +44789,7 @@
             }
           },
           {
-            "description": "Unix timestamp for the start of the lookback period (defaults to current time if omitted)",
+            "description": "Unix timestamp (seconds since epoch) for the start of the lookback period. Must be positive, in the past, and within the last year. Mutually exclusive with lookbackDays; exactly one must be provided.",
             "in": "query",
             "name": "lookbackStart",
             "schema": {
@@ -39507,7 +44821,7 @@
     },
     "/api/orgs/{orgName}/services": {
       "get": {
-        "description": "Returns all service accounts in an organization. Service accounts provide programmatic, non-human identities for accessing Pulumi Cloud resources. They can hold access tokens, belong to teams, and have stack permissions, making them suitable for CI/CD pipelines, automation tools, and other machine-to-machine integrations.",
+        "description": "Returns all service accounts in an organization. Service accounts provide programmatic, non-human identities for accessing Pulumi Cloud resources. They can hold access tokens, belong to teams, and have stack permissions, making them suitable for CI/CD pipelines, automation tools, and other machine-to-machine integrations. Results are paginated; use `continuationToken` and `maxResults` to page through services.",
         "operationId": "ListServices",
         "parameters": [
           {
@@ -39517,6 +44831,23 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Token from a previous response to fetch the next page of services",
+            "in": "query",
+            "name": "continuationToken",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of services to return per page (max 1000)",
+            "in": "query",
+            "name": "maxResults",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
             }
           }
         ],
@@ -39534,7 +44865,8 @@
         },
         "summary": "ListServices",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       },
       "post": {
@@ -39584,7 +44916,8 @@
         },
         "summary": "CreateService",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       }
     },
@@ -39654,11 +44987,12 @@
         },
         "summary": "DeleteService",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       },
       "get": {
-        "description": "Returns the details of a specific service account, including its name, owner, description, team memberships, access tokens, and stack permissions. Service accounts provide programmatic, non-human access to Pulumi Cloud resources and are identified by their owner type, owner name, and service name.",
+        "description": "Returns the details of a specific service account, including its name, owner, description, team memberships, access tokens, and stack permissions. Service accounts provide programmatic, non-human access to Pulumi Cloud resources and are identified by their owner type, owner name, and service name. The returned items list is paginated; use `continuationToken` and `maxResults` to page through items.",
         "operationId": "GetService",
         "parameters": [
           {
@@ -39696,6 +45030,23 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Token from a previous response to fetch the next page of items",
+            "in": "query",
+            "name": "continuationToken",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of items to return per page (max 1000)",
+            "in": "query",
+            "name": "maxResults",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -39712,7 +45063,8 @@
         },
         "summary": "GetService",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       },
       "head": {
@@ -39763,7 +45115,8 @@
         },
         "summary": "HeadService",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       },
       "patch": {
@@ -39837,14 +45190,203 @@
         },
         "summary": "UpdateService",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       }
     },
     "/api/orgs/{orgName}/services/{ownerType}/{ownerName}/{serviceName}/items": {
       "post": {
-        "description": "Adds items (such as access tokens, team memberships, or stack permissions) to an existing service account. Service accounts provide programmatic, non-human access to Pulumi Cloud resources and are scoped to an organization. Items define what the service account can access and what credentials it holds. Returns the updated service details.",
+        "deprecated": true,
+        "description": "Adds items (such as access tokens, team memberships, or stack permissions) to an existing service account. Service accounts provide programmatic, non-human access to Pulumi Cloud resources and are scoped to an organization. Items define what the service account can access and what credentials it holds. Returns the updated service details with the first page of items; if `continuationToken` is set on the response, pass it to `GetService` to fetch the remaining pages.\n\nPrefer `AddServiceItemsV2`, then `GetService` to read the items.",
         "operationId": "AddServiceItems",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner type",
+            "in": "path",
+            "name": "ownerType",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner name",
+            "in": "path",
+            "name": "ownerName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The service name",
+            "in": "path",
+            "name": "serviceName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of items to return on the first page (max 1000)",
+            "in": "query",
+            "name": "maxResults",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddServiceItemsRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetServiceResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid service item data provided."
+          }
+        },
+        "summary": "AddServiceItems",
+        "tags": [
+          "Organizations",
+          "Services"
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "RemovalDate": "2026-08-25",
+          "SupersededBy": "AddServiceItemsV2",
+          "Visibility": "Public"
+        }
+      }
+    },
+    "/api/orgs/{orgName}/services/{ownerType}/{ownerName}/{serviceName}/items/{itemType}/{itemName}": {
+      "delete": {
+        "deprecated": true,
+        "description": "Removes a specific item (such as a team membership, access token, or stack permission) from a service account. Returns the updated service details after the item has been removed, with the first page of items; if `continuationToken` is set on the response, pass it to `GetService` to fetch the remaining pages.\n\nPrefer `RemoveServiceItemV2`, then `GetService` to read the items.",
+        "operationId": "RemoveServiceItem",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner type",
+            "in": "path",
+            "name": "ownerType",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner name",
+            "in": "path",
+            "name": "ownerName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The service name",
+            "in": "path",
+            "name": "serviceName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The item type",
+            "in": "path",
+            "name": "itemType",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The item name",
+            "in": "path",
+            "name": "itemName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of items to return on the first page (max 1000)",
+            "in": "query",
+            "name": "maxResults",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetServiceResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid item name"
+          }
+        },
+        "summary": "RemoveServiceItem",
+        "tags": [
+          "Organizations",
+          "Services"
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "RemovalDate": "2026-08-25",
+          "SupersededBy": "RemoveServiceItemV2",
+          "Visibility": "Public"
+        }
+      }
+    },
+    "/api/orgs/{orgName}/services/{ownerType}/{ownerName}/{serviceName}/v2/items": {
+      "post": {
+        "description": "Adds items (such as access tokens, team memberships, or stack permissions) to an existing service account. Service accounts provide programmatic, non-human access to Pulumi Cloud resources and are scoped to an organization. Items define what the service account can access and what credentials it holds. Call `GetService` to read the items list.",
+        "operationId": "AddServiceItemsV2",
         "parameters": [
           {
             "description": "The organization name",
@@ -39894,30 +45436,24 @@
           "x-originalParamName": "body"
         },
         "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetServiceResponse"
-                }
-              }
-            },
-            "description": "OK"
+          "204": {
+            "description": "No Content"
           },
           "400": {
             "description": "Invalid service item data provided."
           }
         },
-        "summary": "AddServiceItems",
+        "summary": "AddServiceItemsV2",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       }
     },
-    "/api/orgs/{orgName}/services/{ownerType}/{ownerName}/{serviceName}/items/{itemType}/{itemName}": {
+    "/api/orgs/{orgName}/services/{ownerType}/{ownerName}/{serviceName}/v2/items/{itemType}/{itemName}": {
       "delete": {
-        "description": "Removes a specific item (such as a team membership, access token, or stack permission) from a service account. Returns the updated service details after the item has been removed.",
-        "operationId": "RemoveServiceItem",
+        "description": "Removes a specific item (such as a team membership, access token, or stack permission) from a service account. Removing an item that is not in the service succeeds with no effect. Call `GetService` to read the updated items list.",
+        "operationId": "RemoveServiceItemV2",
         "parameters": [
           {
             "description": "The organization name",
@@ -39975,23 +45511,17 @@
           }
         ],
         "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetServiceResponse"
-                }
-              }
-            },
-            "description": "OK"
+          "204": {
+            "description": "No Content"
           },
           "400": {
-            "description": "invalid item name"
+            "description": "Invalid item type."
           }
         },
-        "summary": "RemoveServiceItem",
+        "summary": "RemoveServiceItemV2",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Services"
         ]
       }
     },
@@ -40207,7 +45737,7 @@
         ]
       },
       "patch": {
-        "description": "Updates a team's membership and configuration. The request can add or remove organization members, update the team's display name or description, and modify stack permission grants. Members added to a team inherit the team's stack permissions. Team members can have the role of team admin (can manage team membership) or team member (standard access). Teams are not available to individual (single-user) organizations.",
+        "description": "Updates a team's membership and configuration. This multi-purpose endpoint supports several operations:\n\n**Update membership:** Use `member` (username) and `memberAction` (`add` or `remove`) to manage team members.\n\n**Grant stack access:** Use `addStackPermission` with `projectName`, `stackName`, and `permission` (integer: `101` = read, `102` = edit, `103` = admin).\n\n**Remove stack access:** Use `removeStack` with `projectName` and `stackName`.\n\nMembers added to a team inherit the team's stack permissions. Teams are not available to individual (single-user) organizations.",
         "operationId": "UpdateTeam",
         "parameters": [
           {
@@ -40485,7 +46015,7 @@
         ]
       },
       "post": {
-        "description": "Generates a new access token scoped to a specific team within an organization. Team tokens inherit the stack permissions assigned to the team, making them suitable for CI/CD pipelines that need access limited to a specific set of stacks. The request body specifies the token name, description, and optional expiration. The response includes the token value which is only returned once at creation time and cannot be retrieved later. Actions performed with team tokens are attributed to the team in audit logs.",
+        "description": "Generates a new access token scoped to a specific team within an organization. Team tokens inherit the stack permissions assigned to the team, making them suitable for CI/CD pipelines that need access limited to a specific set of stacks.\n\nThe `name` field must be unique across the organization (including deleted tokens) and cannot exceed 40 characters. The `expires` field accepts a unix epoch timestamp up to two years from the present, or `0` for no expiry (default).\n\n**Important:** The token value in the response is only returned once at creation time and cannot be retrieved later.",
         "operationId": "CreateTeamToken",
         "parameters": [
           {
@@ -41011,11 +46541,12 @@
         },
         "summary": "ListOrgTokens",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AccessTokens"
         ]
       },
       "post": {
-        "description": "Generates a new access token scoped to the organization for use in CI/CD pipelines and automated workflows. Organization tokens belong to the organization rather than individual users, ensuring that access is not disrupted when team members leave. Token names must be unique across the organization. The request body specifies the token name, description, and optional expiration. The response includes the token value which is only returned once at creation time and cannot be retrieved later. Audit logs and update history for actions performed with organization tokens are attributed to the organization rather than an individual user.",
+        "description": "Generates a new access token scoped to the organization for use in CI/CD pipelines and automated workflows. Organization tokens belong to the organization rather than individual users, ensuring that access is not disrupted when team members leave.\n\nThe `name` field must be unique across the organization (including deleted tokens) and cannot exceed 40 characters. The `expires` field accepts a unix epoch timestamp up to two years from the present, or `0` for no expiry (default).\n\n**Important:** The token value in the response is only returned once at creation time and cannot be retrieved later. Audit logs for actions performed with organization tokens are attributed to the organization rather than an individual user.",
         "operationId": "CreateOrgToken",
         "parameters": [
           {
@@ -41060,7 +46591,8 @@
         },
         "summary": "CreateOrgToken",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AccessTokens"
         ]
       }
     },
@@ -41095,7 +46627,8 @@
         },
         "summary": "DeleteOrgToken",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "AccessTokens"
         ]
       }
     },
@@ -41129,6 +46662,72 @@
               "format": "int64",
               "type": "integer"
             }
+          },
+          {
+            "description": "Field to sort the results by. Defaults to lastEvent.",
+            "in": "query",
+            "name": "sortBy",
+            "schema": {
+              "enum": [
+                "lastEvent",
+                "created",
+                "status",
+                "name",
+                "tokensUsed"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "The field used to sort Neo agent tasks in list results.",
+                "enumFieldComments": [
+                  "Sort by the time of the most recent event on the task.",
+                  "Sort by when the task was created.",
+                  "Sort by task status, with running ordered before idle when ascending.",
+                  "Sort by task name.",
+                  "Sort by total Neo tokens consumed by the task. Tasks with no reported usage are treated as zero."
+                ],
+                "enumTypeName": "AgentTaskSortField"
+              }
+            }
+          },
+          {
+            "description": "Direction to sort the results in. Defaults to desc.",
+            "in": "query",
+            "name": "sortDirection",
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "The direction used when sorting Neo agent tasks.",
+                "enumFieldComments": [
+                  "Sort in ascending order.",
+                  "Sort in descending order."
+                ],
+                "enumTypeName": "AgentTaskSortDirection"
+              }
+            }
+          },
+          {
+            "description": "Task type to filter by",
+            "in": "query",
+            "name": "taskType",
+            "schema": {
+              "enum": [
+                "sync",
+                "async"
+              ],
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "The origin category for a Neo agent task.",
+                "enumFieldComments": [
+                  "A task started directly by a user in an interactive flow.",
+                  "A task started asynchronously by background signal infrastructure."
+                ],
+                "enumTypeName": "AgentTaskType"
+              }
+            }
           }
         ],
         "responses": {
@@ -41148,11 +46747,15 @@
         },
         "summary": "ListTasks",
         "tags": [
-          "AI Agents"
-        ]
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "post": {
-        "description": "Creates a new agent task for the specified organization. The request must include a prompt (the user event message) that initiates the task. Set the 'permissionMode' field in the request body to restrict the agent to read-only operations. Returns the created task details including task ID, name, status, and timestamp.",
+        "description": "Creates a new agent task for the specified organization. The request must include a prompt (the user event message) that initiates the task. The message is a user message, so its discriminator field must be set to \"type\": \"user_message\". Set the 'permissionMode' field in the request body to restrict the agent to read-only operations. Returns the created task details including task ID, name, status, and timestamp.",
         "operationId": "CreateTasks",
         "parameters": [
           {
@@ -41192,8 +46795,12 @@
         },
         "summary": "CreateTasks",
         "tags": [
-          "AI Agents"
-        ]
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/agents/{orgName}/tasks/{taskID}": {
@@ -41237,8 +46844,12 @@
         },
         "summary": "GetTask",
         "tags": [
-          "AI Agents"
-        ]
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "patch": {
         "description": "Updates the settings or metadata of an agent task. Only the user who created the task can modify it.",
@@ -41293,8 +46904,12 @@
         },
         "summary": "UpdateTask",
         "tags": [
-          "AI Agents"
-        ]
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "post": {
         "description": "Sends a response to an ongoing agent task. Supported event types include user_message, user_confirmation, and user_cancel. Returns 409 if the task already has a pending request that has not completed.",
@@ -41345,8 +46960,70 @@
         },
         "summary": "RespondToTask",
         "tags": [
-          "AI Agents"
-        ]
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/preview/agents/{orgName}/tasks/{taskID}/cancel": {
+      "post": {
+        "description": "Cancels an agent task. When force is true, immediately terminates the runtime session and resets the task to idle. This is the escalation path when a graceful cancel (via the user_cancel event in RespondToTask) is insufficient or the task is stuck. Unlike graceful cancel, force-cancel does not attempt to notify the agent runtime — it kills the session directly and resets the task state. Currently only force cancellation is supported; the force field must be set to true. Returns 409 if the session was stopped but the task status could not be reset to idle.",
+        "operationId": "CancelTask",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The agent task identifier",
+            "in": "path",
+            "name": "taskID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelAgentTaskRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "Task cancelled successfully"
+          },
+          "400": {
+            "description": "force must be true (graceful cancel not yet supported via this endpoint)"
+          },
+          "404": {
+            "description": "task"
+          },
+          "409": {
+            "description": "session stopped but task status could not be reset to idle"
+          }
+        },
+        "summary": "CancelTask",
+        "tags": [
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/agents/{orgName}/tasks/{taskID}/events": {
@@ -41410,8 +47087,61 @@
         },
         "summary": "GetTaskEvents",
         "tags": [
-          "AI Agents"
-        ]
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/preview/agents/{orgName}/tasks/{taskID}/events/stream": {
+      "get": {
+        "description": "Streams events for a specific agent task as Server-Sent Events. Each SSE data frame contains a JSON-encoded AgentConsoleEvent. The stream delivers existing events immediately, then keeps the connection open to deliver new events in real time until the task completes.",
+        "operationId": "StreamTaskEvents",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The agent task identifier",
+            "in": "path",
+            "name": "taskID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentConsoleEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "task"
+          }
+        },
+        "summary": "StreamTaskEvents",
+        "tags": [
+          "AI Agents",
+          "Neo"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments": {
@@ -41472,7 +47202,12 @@
         "summary": "ListEnvironments",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListEnvironments_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/providers": {
@@ -41505,7 +47240,12 @@
         "summary": "ListProviders",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListProviders_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/providers/{providerName}/schema": {
@@ -41548,7 +47288,12 @@
         "summary": "GetProviderSchema",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetProviderSchema_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}": {
@@ -41624,7 +47369,12 @@
         "summary": "ListOrgEnvironments",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListOrgEnvironments_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/tags": {
@@ -41673,7 +47423,12 @@
         "summary": "ListAllEnvironmentTags",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListAllEnvironmentTags_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/yaml/check": {
@@ -41724,7 +47479,12 @@
         "summary": "CheckYAML",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CheckYAML_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/yaml/open": {
@@ -41775,7 +47535,12 @@
         "summary": "OpenYAML",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "OpenYAML_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/yaml/open/{openSessionID}": {
@@ -41835,7 +47600,12 @@
         "summary": "ReadAnonymousOpenEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ReadAnonymousOpenEnvironment_esc",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}": {
@@ -41880,7 +47650,12 @@
         "summary": "DeleteEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DeleteEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "deprecated": true,
@@ -41930,7 +47705,12 @@
         "summary": "ReadEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ReadEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "head": {
         "deprecated": true,
@@ -41980,7 +47760,12 @@
         "summary": "HeadEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "HeadEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "patch": {
         "deprecated": true,
@@ -42040,7 +47825,12 @@
         "summary": "UpdateEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "UpdateEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "post": {
         "deprecated": true,
@@ -42093,7 +47883,12 @@
         "summary": "CreateEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CreateEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/check": {
@@ -42153,7 +47948,12 @@
         "summary": "CheckEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CheckEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/decrypt": {
@@ -42205,7 +48005,12 @@
         "summary": "DecryptEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DecryptEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/hooks": {
@@ -42251,7 +48056,12 @@
         "summary": "ListWebhooks",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListWebhooks_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "post": {
         "deprecated": true,
@@ -42308,7 +48118,12 @@
         "summary": "CreateWebhook",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CreateWebhook_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/hooks/{hookName}": {
@@ -42353,7 +48168,12 @@
         "summary": "DeleteWebhook",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DeleteWebhook_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "deprecated": true,
@@ -42406,7 +48226,12 @@
         "summary": "GetWebhook",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetWebhook_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "patch": {
         "deprecated": true,
@@ -42472,7 +48297,12 @@
         "summary": "UpdateWebhook",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "UpdateWebhook_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/hooks/{hookName}/deliveries": {
@@ -42527,7 +48357,12 @@
         "summary": "GetWebhookDeliveries",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetWebhookDeliveries_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/hooks/{hookName}/deliveries/{event}/redeliver": {
@@ -42591,7 +48426,12 @@
         "summary": "RedeliverWebhookEvent",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "RedeliverWebhookEvent_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/hooks/{hookName}/ping": {
@@ -42646,7 +48486,12 @@
         "summary": "PingWebhook",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PingWebhook_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/metadata": {
@@ -42698,7 +48543,12 @@
         "summary": "GetEnvironmentMetadata",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetEnvironmentMetadata_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/open": {
@@ -42758,7 +48608,12 @@
         "summary": "OpenEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "OpenEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/open/{openSessionID}": {
@@ -42827,7 +48682,12 @@
         "summary": "ReadOpenEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ReadOpenEnvironment_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/tags": {
@@ -42897,7 +48757,12 @@
         "summary": "ListEnvironmentTags",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListEnvironmentTags_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "post": {
         "deprecated": true,
@@ -42957,7 +48822,12 @@
         "summary": "CreateEnvironmentTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CreateEnvironmentTag_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/tags/{tagName}": {
@@ -43011,7 +48881,12 @@
         "summary": "DeleteEnvironmentTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DeleteEnvironmentTag_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "deprecated": true,
@@ -43064,7 +48939,12 @@
         "summary": "GetEnvironmentTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetEnvironmentTag_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "patch": {
         "deprecated": true,
@@ -43133,7 +49013,12 @@
         "summary": "UpdateEnvironmentTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "UpdateEnvironmentTag_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions": {
@@ -43206,7 +49091,12 @@
         "summary": "ListEnvironmentRevisions",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListEnvironmentRevisions_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/tags": {
@@ -43275,7 +49165,12 @@
         "summary": "ListRevisionTags",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListRevisionTags_esc_environments_versions",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/tags/{tagName}": {
@@ -43329,7 +49224,12 @@
         "summary": "DeleteRevisionTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DeleteRevisionTag_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "deprecated": true,
@@ -43388,7 +49288,12 @@
         "summary": "ReadRevisionTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ReadRevisionTag_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "patch": {
         "deprecated": true,
@@ -43450,7 +49355,12 @@
         "summary": "UpdateRevisionTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "UpdateRevisionTag_esc_environments",
+          "Visibility": "Preview"
+        }
       },
       "post": {
         "deprecated": true,
@@ -43512,7 +49422,12 @@
         "summary": "CreateRevisionTag",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CreateRevisionTag_esc_environments_versions_tags",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}": {
@@ -43573,7 +49488,12 @@
         "summary": "ReadEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ReadEnvironment_esc_environments_versions",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}/check": {
@@ -43642,7 +49562,12 @@
         "summary": "CheckEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "CheckEnvironment_esc_environments_versions",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}/decrypt": {
@@ -43703,7 +49628,12 @@
         "summary": "DecryptEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DecryptEnvironment_esc_environments_versions",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}/open": {
@@ -43772,7 +49702,12 @@
         "summary": "OpenEnvironment",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "OpenEnvironment_esc_environments_versions",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}/referrers": {
@@ -43866,7 +49801,12 @@
         "summary": "ListEnvironmentReferrers",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListEnvironmentReferrers_esc_environments_versions",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}/retract": {
@@ -43930,7 +49870,12 @@
         "summary": "RetractEnvironmentRevision",
         "tags": [
           "Environments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "RetractEnvironmentRevision_esc_environments",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/environments/{orgName}/{envName}/versions/{version}/tags": {
@@ -44008,292 +49953,12 @@
         "summary": "ListRevisionTags",
         "tags": [
           "Environments"
-        ]
-      }
-    },
-    "/api/preview/esc/environments/{orgName}/{projectName}/{envName}/drafts": {
-      "post": {
-        "description": "Creates a new draft change request for a Pulumi ESC environment. Drafts allow proposing changes to an environment definition that can be reviewed and approved before being applied. This is part of the approvals workflow for environments. Returns a ChangeRequestRef containing the draft identifier. Requires the Approvals feature to be enabled for the organization.",
-        "operationId": "CreateEnvironmentDraft_preview",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The project name",
-            "in": "path",
-            "name": "projectName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The environment name",
-            "in": "path",
-            "name": "envName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
         ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangeRequestRef"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad request"
-          },
-          "404": {
-            "description": "draft"
-          },
-          "409": {
-            "description": "the environment has changed since it was read"
-          }
-        },
-        "summary": "CreateEnvironmentDraft",
-        "tags": [
-          "Environments"
-        ]
-      }
-    },
-    "/api/preview/esc/environments/{orgName}/{projectName}/{envName}/drafts/{changeRequestID}": {
-      "get": {
-        "description": "Reads the YAML definition for a draft version of a Pulumi ESC environment. Drafts are proposed changes created as part of the approvals workflow. The draft is identified by the changeRequestID path parameter. An optional revision query parameter can target a specific base revision. The response is returned in application/x-yaml format. Requires the Approvals feature to be enabled.",
-        "operationId": "ReadEnvironmentDraft_preview",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The project name",
-            "in": "path",
-            "name": "projectName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The environment name",
-            "in": "path",
-            "name": "envName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The change request ID",
-            "in": "path",
-            "name": "changeRequestID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The environment revision number to target",
-            "in": "query",
-            "name": "revision",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/x-yaml": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Invalid input"
-          }
-        },
-        "summary": "ReadEnvironmentDraft",
-        "tags": [
-          "Environments"
-        ]
-      },
-      "patch": {
-        "description": "Updates the YAML definition of an existing draft change request for a Pulumi ESC environment. The draft is identified by the changeRequestID path parameter. The request body contains the updated YAML definition. Returns a ChangeRequestRef on success. Requires the Approvals feature to be enabled for the organization.",
-        "operationId": "UpdateEnvironmentDraft_preview",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The project name",
-            "in": "path",
-            "name": "projectName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The environment name",
-            "in": "path",
-            "name": "envName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The change request ID",
-            "in": "path",
-            "name": "changeRequestID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangeRequestRef"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad request"
-          },
-          "404": {
-            "description": "draft"
-          },
-          "409": {
-            "description": "the environment has changed since it was read"
-          }
-        },
-        "summary": "UpdateEnvironmentDraft",
-        "tags": [
-          "Environments"
-        ]
-      }
-    },
-    "/api/preview/esc/environments/{orgName}/{projectName}/{envName}/drafts/{changeRequestID}/open": {
-      "post": {
-        "description": "Opens a draft version of a Pulumi ESC environment, fully resolving all dynamic values, provider integrations, and secrets for the proposed changes. The duration parameter specifies how long the open session remains valid using Go duration format (e.g., '2h', '30m'). An optional revision parameter can target a specific base revision. Returns an OpenEnvironmentResponse containing the session ID for subsequent reads. Requires the Approvals feature.",
-        "operationId": "OpenEnvironmentDraft_preview",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The project name",
-            "in": "path",
-            "name": "projectName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The environment name",
-            "in": "path",
-            "name": "envName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The change request ID",
-            "in": "path",
-            "name": "changeRequestID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The session duration, using Go time units: ns, us, ms, s, m, h (e.g. '2h')",
-            "in": "query",
-            "name": "duration",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The environment revision number to target",
-            "in": "query",
-            "name": "revision",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OpenEnvironmentResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "invalid query parameter"
-          },
-          "404": {
-            "description": "Change Request"
-          },
-          "409": {
-            "description": "the environment has changed since it was read"
-          }
-        },
-        "summary": "OpenEnvironmentDraft",
-        "tags": [
-          "Environments"
-        ]
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListRevisionTags_esc_environments_versions2",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts": {
@@ -44364,8 +50029,63 @@
         },
         "summary": "ListAccounts",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "post": {
+        "description": "Creates multiple Insights accounts in a single operation. Each account is created independently, so a failure to create one account does not prevent other accounts from being created. Returns the list of successfully created accounts and details about any failures. Accounts are created with the same permissions as the single CreateAccount endpoint. For AWS accounts, regional child accounts are created automatically based on the provider configuration.",
+        "operationId": "BulkCreateAccounts",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkCreateInsightsAccountsRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCreateInsightsAccountsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid request body or empty accounts list"
+          },
+          "404": {
+            "description": "Organization not found"
+          }
+        },
+        "summary": "BulkCreateAccounts",
+        "tags": [
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}": {
@@ -44402,8 +50122,12 @@
         },
         "summary": "DeleteAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "description": "Gets detailed information for a specific Insights account.",
@@ -44445,11 +50169,15 @@
         },
         "summary": "ReadAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "head": {
-        "description": "HeadAccount checks for the existence of an Insights account.",
+        "description": "Checks whether an Insights account exists. Returns 204 if found, 404 otherwise.",
         "operationId": "HeadAccount",
         "parameters": [
           {
@@ -44481,8 +50209,12 @@
         },
         "summary": "HeadAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "patch": {
         "description": "Updates an existing Insights account. Supports partial updates to the ESC environment reference, scan schedule ('none' or 'daily'), and provider-specific configuration such as the list of regions to scan. All request body fields are optional; only provided fields are updated.",
@@ -44530,8 +50262,12 @@
         },
         "summary": "UpdateAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "post": {
         "description": "Creates a new Insights account. An Insights account represents a cloud provider account (e.g., AWS, Azure, OCI) configured for resource discovery.",
@@ -44579,13 +50315,74 @@
         },
         "summary": "CreateAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/preview/insights/{orgName}/accounts/{accountName}/ownership": {
+      "post": {
+        "description": "Changes the ownership of the specified Insights account to the provided user. Returns the identity of the previous owner.",
+        "operationId": "ReassignAccountOwnership",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The Insights account name",
+            "in": "path",
+            "name": "accountName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInfo"
+              }
+            }
+          },
+          "description": "The new owner's identity",
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserInfo"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ReassignAccountOwnership",
+        "tags": [
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/policy/packs": {
       "get": {
-        "description": "ListPolicyPacksForAccount lists the policy packs that should analyze resources in a particular account.",
+        "description": "Returns the policy packs configured to analyze resources in the specified Insights account.",
         "operationId": "ListPolicyPacksForAccount",
         "parameters": [
           {
@@ -44635,13 +50432,17 @@
         },
         "summary": "ListPolicyPacksForAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources": {
       "post": {
-        "description": "UpsertResources upserts Insights resources in an account.",
+        "description": "Creates or updates discovered resources in an Insights account. Used by scanners to report resource state.",
         "operationId": "UpsertResources",
         "parameters": [
           {
@@ -44683,13 +50484,17 @@
         },
         "summary": "UpsertResources",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/references": {
       "post": {
-        "description": "ListResourcesWithReferences returns Insights resources with referenced resources.",
+        "description": "Returns discovered resources along with their referenced resources for a batch of resource identifiers.",
         "operationId": "ListResourcesWithReferences",
         "parameters": [
           {
@@ -44741,13 +50546,17 @@
         },
         "summary": "ListResourcesWithReferences",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}": {
       "get": {
-        "description": "ReadResource returns an Insights resource.",
+        "description": "Returns a discovered resource with its current version details.",
         "operationId": "ReadResource",
         "parameters": [
           {
@@ -44798,13 +50607,17 @@
         },
         "summary": "ReadResource",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/edges": {
       "get": {
-        "description": "ListResourceVersionEdges returns a list of resource edges.",
+        "description": "Returns the relationships (edges) between a discovered resource and other resources in the account.",
         "operationId": "ListResourceVersionEdges",
         "parameters": [
           {
@@ -44872,13 +50685,17 @@
         },
         "summary": "ListResourceVersionEdges",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/references": {
       "get": {
-        "description": "ReadResourceWithReferences returns an Insights resource with referenced resources.",
+        "description": "Returns a discovered resource along with its referenced (related) resources.",
         "operationId": "ReadResourceWithReferences",
         "parameters": [
           {
@@ -44923,13 +50740,17 @@
         },
         "summary": "ReadResourceWithReferences",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/stack_edges": {
       "get": {
-        "description": "ListResourceStackEdges returns a list of resource stack edges.",
+        "description": "Returns the Pulumi stacks that manage the specified discovered resource.",
         "operationId": "ListResourceStackEdges",
         "parameters": [
           {
@@ -44977,13 +50798,17 @@
         },
         "summary": "ListResourceStackEdges",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/versions": {
       "get": {
-        "description": "ListResourceVersions returns a list of resource versions.",
+        "description": "Returns the version history for a discovered resource, showing how its configuration has changed over time.",
         "operationId": "ListResourceVersions",
         "parameters": [
           {
@@ -45051,13 +50876,17 @@
         },
         "summary": "ListResourceVersions",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/versions/{resourceVersion}": {
       "get": {
-        "description": "ReadResource returns an Insights resource.",
+        "description": "Returns a discovered resource with its current or specified version details.",
         "operationId": "ReadResource_versions",
         "parameters": [
           {
@@ -45117,13 +50946,17 @@
         },
         "summary": "ReadResource",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/versions/{resourceVersion}/edges": {
       "get": {
-        "description": "ListResourceVersionEdges returns a list of resource edges.",
+        "description": "Returns the relationships (edges) between a discovered resource and other resources in the account.",
         "operationId": "ListResourceVersionEdges_versions",
         "parameters": [
           {
@@ -45201,13 +51034,17 @@
         },
         "summary": "ListResourceVersionEdges",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/resources/{resourceTypeAndId}/versions/{resourceVersion}/policy/results": {
       "put": {
-        "description": "UpdateResourceVersionPolicyResults updates the policy results for a resource version.",
+        "description": "Updates the policy evaluation results for a specific version of a discovered resource.",
         "operationId": "UpdateResourceVersionPolicyResults",
         "parameters": [
           {
@@ -45270,13 +51107,17 @@
         },
         "summary": "UpdateResourceVersionPolicyResults",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scan": {
       "get": {
-        "description": "ReadScanStatus reads the status of the latest scan for an Insights account.",
+        "description": "Returns the status of the most recent scan for an Insights account.",
         "operationId": "ReadScanStatus",
         "parameters": [
           {
@@ -45315,11 +51156,15 @@
         },
         "summary": "ReadScanStatus",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "post": {
-        "description": "ScanAccount starts an Insights scan.",
+        "description": "Starts a resource discovery scan for an Insights account. For parent accounts, triggers scans across all child accounts.",
         "operationId": "ScanAccount",
         "parameters": [
           {
@@ -45374,13 +51219,17 @@
         },
         "summary": "ScanAccount",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scan/cancel": {
       "post": {
-        "description": "CancelScan cancels a running scan for an Insights account.",
+        "description": "Cancels a running resource discovery scan for an Insights account.",
         "operationId": "CancelScan",
         "parameters": [
           {
@@ -45412,8 +51261,12 @@
         },
         "summary": "CancelScan",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scan/pause": {
@@ -45447,8 +51300,12 @@
         },
         "summary": "PauseScheduledScans",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scan/resume": {
@@ -45482,13 +51339,17 @@
         },
         "summary": "ResumeScheduledScans",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scan/settings": {
       "get": {
-        "description": "ReadScheduledScanSettings reads the scheduled scan settings for an Insights account.",
+        "description": "Returns the scheduled scan configuration for an Insights account, including scan frequency and schedule details.",
         "operationId": "ReadScheduledScanSettings",
         "parameters": [
           {
@@ -45527,11 +51388,15 @@
         },
         "summary": "ReadScheduledScanSettings",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "put": {
-        "description": "UpdateScheduledScanSettings updates the scheduled scan settings for an Insights account.",
+        "description": "Updates the scheduled scan configuration for an Insights account, such as scan frequency and schedule.",
         "operationId": "UpdateScheduledScanSettings",
         "parameters": [
           {
@@ -45573,13 +51438,17 @@
         },
         "summary": "UpdateScheduledScanSettings",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scans": {
       "get": {
-        "description": "ListScanStatus lists scan history for an insights account, including child accounts for parent accounts.",
+        "description": "Returns the scan history for an Insights account, including child accounts for parent accounts.",
         "operationId": "ListScanStatus",
         "parameters": [
           {
@@ -45638,13 +51507,17 @@
         },
         "summary": "ListScanStatus",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scans/{scanId}": {
       "get": {
-        "description": "GetScan fetches details for a specific Insights scan by ID.",
+        "description": "Returns details for a specific Insights scan, including its status, timestamps, and resource counts.",
         "operationId": "GetScan",
         "parameters": [
           {
@@ -45692,13 +51565,17 @@
         },
         "summary": "GetScan",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/scans/{scanId}/logs": {
       "get": {
-        "description": "GetScanLogs fetches logs for a specific Insights scan by ID.\nIf the 'job' query parameter is present, defer to the step logs handler, which supports job/step offsets.\nOtherwise, the continuationToken and count query parameters are used to page through the logs.",
+        "description": "Returns log output for a specific Insights scan. Supports two modes: when the 'job' parameter is provided, returns step-level logs with job/step offsets; otherwise, uses continuationToken and count for paginated log retrieval.",
         "operationId": "GetScanLogs",
         "parameters": [
           {
@@ -45793,13 +51670,17 @@
         },
         "summary": "GetScanLogs",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/tags": {
       "get": {
-        "description": "GetInsightAccountTags returns all tags for an Insights account as a key-value map.",
+        "description": "Returns all tags for an Insights account as a key-value map.",
         "operationId": "GetInsightAccountTags",
         "parameters": [
           {
@@ -45838,11 +51719,15 @@
         },
         "summary": "GetInsightAccountTags",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       },
       "put": {
-        "description": "SetInsightAccountTags atomically replaces all tags for an Insights account with the provided dictionary. For AWS parent accounts, changes cascade to all child accounts.",
+        "description": "Atomically replaces all tags for an Insights account with the provided key-value pairs. For AWS parent accounts, tag changes cascade to all child accounts.",
         "operationId": "SetInsightAccountTags",
         "parameters": [
           {
@@ -45890,13 +51775,17 @@
         },
         "summary": "SetInsightAccountTags",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/teams": {
       "get": {
-        "description": "ListInsightsAccountTeams lists teams associated with an account",
+        "description": "Returns the teams that have been granted access to an Insights account.",
         "operationId": "ListInsightsAccountTeams",
         "parameters": [
           {
@@ -45932,13 +51821,17 @@
         },
         "summary": "ListInsightsAccountTeams",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/accounts/{accountName}/teams/{teamName}": {
       "patch": {
-        "description": "UpdateTeamInsightsAccountPermissions updates the permissions that a team has on an account",
+        "description": "Updates the permissions that a team has on an Insights account.",
         "operationId": "UpdateTeamInsightsAccountPermissions",
         "parameters": [
           {
@@ -45989,8 +51882,12 @@
         },
         "summary": "UpdateTeamInsightsAccountPermissions",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/discovered-stacks/{projectName}": {
@@ -46042,8 +51939,12 @@
         },
         "summary": "GetDiscoveredProject",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}": {
@@ -46096,14 +51997,76 @@
         },
         "summary": "GetDiscoveredStack",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
-    "/api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}/resources": {
-      "get": {
-        "description": "Returns the list of resources in a discovered stack.",
-        "operationId": "ListDiscoveredStackResources",
+    "/api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}/migration": {
+      "delete": {
+        "description": "Removes a migration annotation from a discovered resource. The resource is identified by its URN passed as a query parameter.",
+        "operationId": "DeleteResourceMigrationAnnotation",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The discovered project name",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The discovered stack name",
+            "in": "path",
+            "name": "stackName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "URN of the resource to remove the annotation from",
+            "in": "query",
+            "name": "resourceUrn",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Discovered stack or annotation not found"
+          }
+        },
+        "summary": "DeleteResourceMigrationAnnotation",
+        "tags": [
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "put": {
+        "description": "Creates or updates a migration annotation on a discovered resource. The resource is identified by its URN in the request body. At least one of note or statusOverride must be non-empty; requests with both empty are rejected with 400. The statusOverride, if provided, must be Migrated or NotApplicable.",
+        "operationId": "UpsertResourceMigrationAnnotation",
         "parameters": [
           {
             "description": "The organization name",
@@ -46133,6 +52096,78 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertResourceMigrationAnnotationRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Discovered stack not found"
+          }
+        },
+        "summary": "UpsertResourceMigrationAnnotation",
+        "tags": [
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/preview/insights/{orgName}/discovered-stacks/{projectName}/{stackName}/resources": {
+      "get": {
+        "description": "Returns the list of resources in a discovered stack, each annotated with a migrationStatus. When compareTo is provided, resource identities are matched against the target Pulumi stack.",
+        "operationId": "ListDiscoveredStackResources",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The discovered project name",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The discovered stack name",
+            "in": "path",
+            "name": "stackName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pulumi stack to compare against in project/stack format. Must be in the same org.",
+            "in": "query",
+            "name": "compareTo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -46150,13 +52185,17 @@
         },
         "summary": "ListDiscoveredStackResources",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/import/code/generate": {
       "post": {
-        "description": "GenerateImportCode generates code in the specified language to import resources.",
+        "description": "Generates Pulumi code in the specified language to import discovered resources into a Pulumi stack.",
         "operationId": "GenerateImportCode",
         "parameters": [
           {
@@ -46196,13 +52235,17 @@
         },
         "summary": "GenerateImportCode",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/insightstrial/accept": {
       "put": {
-        "description": "AcceptInsightsBilling accepts insights billing charges.",
+        "description": "Accepts Insights billing charges for the specified organization, enabling metered billing for resource discovery.",
         "operationId": "AcceptInsightsBilling",
         "parameters": [
           {
@@ -46225,13 +52268,17 @@
         },
         "summary": "AcceptInsightsBilling",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/insightstrial/deny": {
       "put": {
-        "description": "updates insights trial status and deletes all accounts",
+        "description": "Terminates the Insights trial for the organization and removes all associated accounts.",
         "operationId": "TerminateInsightsTrial",
         "parameters": [
           {
@@ -46254,13 +52301,17 @@
         },
         "summary": "TerminateInsightsTrial",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/insightstrial/summary": {
       "get": {
-        "description": "GetInsightsTrialSummary returns insights trial usage summary.",
+        "description": "Returns a summary of the organization's Insights trial usage, including resource counts and remaining trial capacity.",
         "operationId": "GetInsightsTrialSummary",
         "parameters": [
           {
@@ -46290,13 +52341,17 @@
         },
         "summary": "GetInsightsTrialSummary",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/insights/{orgName}/policy/stacks/{projectName}/{stackName}/updates/{version}/results": {
       "put": {
-        "description": "UpdateStackPolicyResults updates the policy results for a stack.",
+        "description": "Updates the policy evaluation results for a specific stack update version.",
         "operationId": "UpdateStackPolicyResults",
         "parameters": [
           {
@@ -46360,8 +52415,81 @@
         },
         "summary": "UpdateStackPolicyResults",
         "tags": [
-          "Insights"
-        ]
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/preview/insights/{orgName}/stacks/{projectName}/{stackName}/migration": {
+      "get": {
+        "description": "Returns the resources in a Terraform-backed Pulumi stack, each annotated with a migrationStatus relative to an optional comparison Pulumi stack. When compareTo is provided in project/stack format, resources matching the target stack are reported as Migrated. Returns 404 with a uniform response shape when the migration feature is not enabled for the organization, when the stack does not exist, or when the stack is not Terraform-backed (runtime tag is not 'terraform-cli'). The shared shape is intentional so callers cannot distinguish 'feature unavailable' from 'stack not found'. Returns 404 with a separate 'Comparison stack' body when compareTo names a stack the caller cannot read (StackRead required) or that does not exist; both return the same shape so existence cannot be probed.",
+        "operationId": "GetStackMigration",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The project name",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The stack name",
+            "in": "path",
+            "name": "stackName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pulumi stack to compare against in project/stack format. Must be in the same org.",
+            "in": "query",
+            "name": "compareTo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDiscoveredStackResourcesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid compareTo parameter"
+          },
+          "404": {
+            "description": "Migration feature disabled, stack not found, or stack is not Terraform-backed"
+          }
+        },
+        "summary": "GetStackMigration",
+        "tags": [
+          "Insights",
+          "InsightsAccounts"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/packages": {
@@ -46454,7 +52582,12 @@
         "summary": "ListPackages",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListPackages",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/packages/{source}/{publisher}/{name}/versions": {
@@ -46522,7 +52655,12 @@
         "summary": "PostPublishPackageVersion",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PostPublishPackageVersion",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}": {
@@ -46576,7 +52714,12 @@
         "summary": "DeletePublishPackageVersion",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DeletePublishPackageVersion",
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "deprecated": true,
@@ -46638,7 +52781,12 @@
         "summary": "GetPackageVersion",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetPackageVersion",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete": {
@@ -46718,391 +52866,12 @@
         "summary": "PostPublishPackageVersionComplete",
         "tags": [
           "RegistryPreview"
-        ]
-      }
-    },
-    "/api/preview/registry/policypacks": {
-      "get": {
-        "deprecated": true,
-        "description": "Lists all policy packs accessible to the calling user for a given organization. The orgLogin query parameter is required and restricts results to policy packs owned by that organization. Results can optionally be filtered by access level. No authentication is required. Returns 400 if the policy pack access filter value is invalid. This is the deprecated GET variant; prefer the POST ListPolicyPacks endpoint instead.",
-        "operationId": "ListPolicyPacks_preview_registry",
-        "parameters": [
-          {
-            "description": "Filter by access level",
-            "in": "query",
-            "name": "access",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Required. Filter by owning organization",
-            "in": "query",
-            "name": "orgLogin",
-            "schema": {
-              "type": "string"
-            }
-          }
         ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListPolicyPacksResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Policy pack access is not valid"
-          }
-        },
-        "summary": "ListPolicyPacks",
-        "tags": [
-          "RegistryPreview"
-        ]
-      },
-      "post": {
-        "description": "Lists all policy packs accessible to the calling user, with support for filtering by access level, organization, and specific policy pack IDs. The request body accepts an optional orgLogin to scope results to a specific organization, an optional access level filter (defaults to 'enabled'), and an optional list of policy pack IDs to restrict the results to specific packs. No authentication is required. Returns 400 if the access filter value is invalid.",
-        "operationId": "ListPolicyPacks_preview_registry_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ListPolicyPacksRequest"
-              }
-            }
-          },
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListPolicyPacksResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Policy pack access is not valid"
-          }
-        },
-        "summary": "ListPolicyPacks",
-        "tags": [
-          "RegistryPreview"
-        ]
-      }
-    },
-    "/api/preview/registry/policypacks/{source}/{publisher}/{name}": {
-      "delete": {
-        "description": "Deletes a policy pack and all of its versions from the registry. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. This is a destructive operation that permanently removes the policy pack and all associated version data. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the policy pack does not exist.",
-        "operationId": "DeletePolicyPack_preview_registry_policypacks",
-        "parameters": [
-          {
-            "description": "The policy pack source: 'private'",
-            "in": "path",
-            "name": "source",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Organization that owns the policy pack",
-            "in": "path",
-            "name": "publisher",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The policy pack name",
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Policy pack not found"
-          }
-        },
-        "summary": "DeletePolicyPack",
-        "tags": [
-          "RegistryPreview"
-        ]
-      }
-    },
-    "/api/preview/registry/policypacks/{source}/{publisher}/{name}/versions": {
-      "get": {
-        "description": "Lists all versions of a specific policy pack. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. The response includes a list of policy pack version metadata and an optional continuationToken for pagination. Returns 404 if the policy pack does not exist.",
-        "operationId": "ListPolicyPackVersions",
-        "parameters": [
-          {
-            "description": "The policy pack source: 'private'",
-            "in": "path",
-            "name": "source",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Organization that owns the policy pack",
-            "in": "path",
-            "name": "publisher",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The policy pack name",
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListPolicyPacksResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "404": {
-            "description": "error getting Registry Policy Pack"
-          }
-        },
-        "summary": "ListPolicyPackVersions",
-        "tags": [
-          "RegistryPreview"
-        ]
-      },
-      "post": {
-        "description": "Initiates the first step of a two-phase policy pack version publish workflow. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. This creates a publish transaction that must be completed by calling PostPublishPolicyPackVersionComplete. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the policy pack is not found.",
-        "operationId": "PostPublishPolicyPackVersion",
-        "parameters": [
-          {
-            "description": "The policy pack source: 'private'",
-            "in": "path",
-            "name": "source",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Organization that owns the policy pack",
-            "in": "path",
-            "name": "publisher",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The policy pack name",
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Policy pack not found"
-          }
-        },
-        "summary": "PostPublishPolicyPackVersion",
-        "tags": [
-          "RegistryPreview"
-        ]
-      }
-    },
-    "/api/preview/registry/policypacks/{source}/{publisher}/{name}/versions/{version}": {
-      "delete": {
-        "description": "Deletes a specific version of a policy pack from the registry. The policy pack version is identified by its source (currently only 'private'), publisher organization, name, and semantic version string. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the specified policy pack version does not exist.",
-        "operationId": "DeletePolicyPack_preview_registry_policypacks_versions",
-        "parameters": [
-          {
-            "description": "The policy pack source: 'private'",
-            "in": "path",
-            "name": "source",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Organization that owns the policy pack",
-            "in": "path",
-            "name": "publisher",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The policy pack name",
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Semantic version string of the policy pack version to delete",
-            "in": "path",
-            "name": "version",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Policy pack not found"
-          }
-        },
-        "summary": "DeletePolicyPack",
-        "tags": [
-          "RegistryPreview"
-        ]
-      },
-      "get": {
-        "description": "Retrieves detailed information about a specific version of a policy pack, including the individual policy definitions. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. The version parameter accepts either a specific semantic version string or the special value 'latest' to retrieve the most recently published version. The response includes the policy pack metadata and an optional list of policies, where each policy includes its configuration schema and enforcement rules. Returns 404 if the specified policy pack does not exist.",
-        "operationId": "GetPolicyPackVersion",
-        "parameters": [
-          {
-            "description": "The policy pack source: 'private'",
-            "in": "path",
-            "name": "source",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Organization that owns the policy pack",
-            "in": "path",
-            "name": "publisher",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The policy pack name",
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Semantic version string or 'latest'",
-            "in": "path",
-            "name": "version",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetRegistryPolicyPackVersionResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "404": {
-            "description": "Policy Pack"
-          }
-        },
-        "summary": "GetPolicyPackVersion",
-        "tags": [
-          "RegistryPreview"
-        ]
-      }
-    },
-    "/api/preview/registry/policypacks/{source}/{publisher}/{name}/versions/{version}/complete": {
-      "post": {
-        "description": "Finalizes the second step of the two-phase policy pack version publish workflow. After initiating a publish with PostPublishPolicyPackVersion, call this endpoint with the policy pack source, publisher, name, and version to complete the publish and make the version available in the registry. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the publish operation is not found.",
-        "operationId": "PostPublishPolicyPackVersionComplete",
-        "parameters": [
-          {
-            "description": "The policy pack source: 'private'",
-            "in": "path",
-            "name": "source",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Organization that owns the policy pack",
-            "in": "path",
-            "name": "publisher",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The policy pack name",
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Semantic version string of the policy pack version to complete",
-            "in": "path",
-            "name": "version",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Publish operation not found"
-          }
-        },
-        "summary": "PostPublishPolicyPackVersionComplete",
-        "tags": [
-          "RegistryPreview"
-        ]
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PostPublishPackageVersionComplete",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/templates": {
@@ -47171,7 +52940,12 @@
         "summary": "ListTemplates",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListTemplates",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/templates/{source}/{publisher}/{name}/versions": {
@@ -47236,7 +53010,12 @@
         "summary": "PostPublishTemplateVersion",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PostPublishTemplateVersion",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/templates/{source}/{publisher}/{name}/versions/{version}": {
@@ -47301,7 +53080,12 @@
         "summary": "DeleteTemplateVersion",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "DeleteTemplateVersion",
+          "Visibility": "Preview"
+        }
       },
       "get": {
         "deprecated": true,
@@ -47366,7 +53150,12 @@
         "summary": "GetTemplateVersion",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "GetTemplateVersion",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/preview/registry/templates/{source}/{publisher}/{name}/versions/{version}/complete": {
@@ -47446,7 +53235,12 @@
         "summary": "PostPublishTemplateVersionComplete",
         "tags": [
           "RegistryPreview"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PostPublishTemplateVersionComplete",
+          "Visibility": "Preview"
+        }
       }
     },
     "/api/projects/{orgName}/{projectName}/batch-decrypt": {
@@ -47990,6 +53784,864 @@
         ]
       }
     },
+    "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/docs/{typeToken}": {
+      "get": {
+        "description": "Returns API documentation for a single resource or function identified by its URL-encoded Pulumi type token. Use 'lang' to filter content to a single language and 'os' to collapse OS choosers in descriptions. Supports JSON or markdown via Accept. Returns 404 if the package version or type token does not exist.",
+        "operationId": "GetPackageDocs",
+        "parameters": [
+          {
+            "description": "The package source: 'pulumi', 'opentofu', or 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the package",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The package name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "URL-encoded Pulumi type token. Encode with JavaScript's encodeURIComponent or an equivalent that percent-encodes reserved characters; e.g. the type token 'random:index/randomPassword:RandomPassword' becomes 'random%3Aindex%2FrandomPassword%3ARandomPassword'.",
+            "in": "path",
+            "name": "typeToken",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter to a single language. Defaults to Go. Values: typescript, python, go, csharp, java, yaml, hcl",
+            "in": "query",
+            "name": "lang",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Collapse OS choosers in descriptions to a single OS. Values: linux, macos, windows",
+            "in": "query",
+            "name": "os",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPackageDocsResponse"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          },
+          "404": {
+            "description": "package version or type token"
+          }
+        },
+        "summary": "GetPackageDocs",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/examples": {
+      "get": {
+        "description": "Returns code examples aggregated across the package's resources and functions. Each example carries its 'typeToken' and 'kind'. Use 'q' for case-insensitive substring search on title and type token. Results are sorted by type token, then by example position within each type token. Use 'limit' (default 20, max 100) to cap returned examples; 'totalCount' reports the unfiltered count. Supports JSON or markdown via Accept. Returns 404 if the package version does not exist.",
+        "operationId": "GetPackageExamples",
+        "parameters": [
+          {
+            "description": "The package source: 'pulumi', 'opentofu', or 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the package",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The package name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Snippet language. Defaults to Go. Values: typescript, python, go, csharp, java, yaml, hcl",
+            "in": "query",
+            "name": "lang",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum examples to return. Default 20; clamped to 100.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "URL-encoded case-insensitive substring filter on title and type token",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPackageExamplesResponse"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          },
+          "404": {
+            "description": "package version"
+          }
+        },
+        "summary": "GetPackageExamples",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/installation": {
+      "get": {
+        "description": "Returns installation configuration as an ordered list of content nodes. Not all packages have installation configuration; returns 404 when absent. Use 'lang' and 'os' to filter language- and OS-specific content. Supports JSON or markdown via Accept. Returns 404 if the package version does not exist or has no installation configuration.",
+        "operationId": "GetPackageInstallation",
+        "parameters": [
+          {
+            "description": "The package source: 'pulumi', 'opentofu', or 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the package",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The package name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter language-specific content to a single language. Values: typescript, python, go, csharp, java, yaml, hcl",
+            "in": "query",
+            "name": "lang",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter OS-specific content to a single OS. Values: linux, macos, windows",
+            "in": "query",
+            "name": "os",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPackageInstallationResponse"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          },
+          "404": {
+            "description": "package version or installation configuration"
+          }
+        },
+        "summary": "GetPackageInstallation",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/nav": {
+      "get": {
+        "description": "Returns the package navigation: a flat list of modules in schema-declaration order. By default returns a summary (module names and counts only) suitable for discovery. Pass 'depth=full' to include resources and functions; combine with 'q' to filter results by name or type token. Module names like 's3/bucket' are flat strings, not nested. Supports JSON or markdown via Accept. Returns 404 if the package version does not exist.",
+        "operationId": "GetPackageNav",
+        "parameters": [
+          {
+            "description": "The package source: 'pulumi', 'opentofu', or 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the package",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The package name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "'summary' (default) returns module names and counts only; 'full' includes resources and functions.",
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Language for name resolution. Defaults to Go. Values: typescript, python, go, csharp, java, yaml, hcl",
+            "in": "query",
+            "name": "lang",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Case-insensitive substring filter on resource/function names and type tokens. Modules with no matches are omitted. Combine with 'depth=full' to return matched items.",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPackageNavResponse"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          },
+          "404": {
+            "description": "package version"
+          }
+        },
+        "summary": "GetPackageNav",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/readme": {
+      "get": {
+        "description": "Returns the package README as an ordered list of content nodes. Each node has a 'kind' and a 'markdown' fallback for unknown kinds. Use 'lang' and 'os' to filter language- and OS-specific content. Supports JSON or markdown via Accept. Returns 404 if the package version does not exist.",
+        "operationId": "GetPackageReadme",
+        "parameters": [
+          {
+            "description": "The package source: 'pulumi', 'opentofu', or 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the package",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The package name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter language-specific content to a single language. Values: typescript, python, go, csharp, java, yaml, hcl",
+            "in": "query",
+            "name": "lang",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter OS-specific content to a single OS. Values: linux, macos, windows",
+            "in": "query",
+            "name": "os",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPackageReadmeResponse"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          },
+          "404": {
+            "description": "package version"
+          }
+        },
+        "summary": "GetPackageReadme",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/api/registry/policypacks": {
+      "get": {
+        "deprecated": true,
+        "description": "Lists all policy packs accessible to the calling user for a given organization. The orgLogin query parameter is required and restricts results to policy packs owned by that organization. Results can optionally be filtered by access level. No authentication is required. Returns 400 if the policy pack access filter value is invalid. This is the deprecated GET variant; prefer the POST ListPolicyPacks endpoint instead.",
+        "operationId": "ListPolicyPacks",
+        "parameters": [
+          {
+            "description": "Filter by access level",
+            "in": "query",
+            "name": "access",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Required. Filter by owning organization",
+            "in": "query",
+            "name": "orgLogin",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPolicyPacksResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Policy pack access is not valid"
+          }
+        },
+        "summary": "ListPolicyPacks",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "ListPolicyPacks_post",
+          "Visibility": "Public"
+        }
+      },
+      "post": {
+        "description": "Lists all policy packs accessible to the calling user, with support for filtering by access level, organization, and specific policy pack IDs. The request body accepts an optional orgLogin to scope results to a specific organization, an optional access level filter (defaults to 'enabled'), and an optional list of policy pack IDs to restrict the results to specific packs. No authentication is required. Returns 400 if the access filter value is invalid.",
+        "operationId": "ListPolicyPacks_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListPolicyPacksRequest"
+              }
+            }
+          },
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPolicyPacksResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Policy pack access is not valid"
+          }
+        },
+        "summary": "ListPolicyPacks",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      }
+    },
+    "/api/registry/policypacks/{source}/{publisher}/{name}": {
+      "delete": {
+        "description": "Deletes a policy pack and all of its versions from the registry. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. This is a destructive operation that permanently removes the policy pack and all associated version data. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the policy pack does not exist.",
+        "operationId": "DeletePolicyPack",
+        "parameters": [
+          {
+            "description": "The policy pack source: 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the policy pack",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The policy pack name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Policy pack not found"
+          }
+        },
+        "summary": "DeletePolicyPack",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      }
+    },
+    "/api/registry/policypacks/{source}/{publisher}/{name}/versions": {
+      "get": {
+        "description": "Lists all versions of a specific policy pack. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. The response includes a list of policy pack version metadata and an optional continuationToken for pagination. Returns 404 if the policy pack does not exist.",
+        "operationId": "ListPolicyPackVersionsForRegistry",
+        "parameters": [
+          {
+            "description": "The policy pack source: 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the policy pack",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The policy pack name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPolicyPacksResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "error getting Registry Policy Pack"
+          }
+        },
+        "summary": "ListPolicyPackVersions",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      },
+      "post": {
+        "description": "Initiates the first step of a two-phase policy pack version publish workflow. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. This creates a publish transaction that must be completed by calling PostPublishPolicyPackVersionComplete. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the policy pack is not found.",
+        "operationId": "PostPublishPolicyPackVersionForRegistry",
+        "parameters": [
+          {
+            "description": "The policy pack source: 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the policy pack",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The policy pack name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Policy pack not found"
+          }
+        },
+        "summary": "PostPublishPolicyPackVersion",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      }
+    },
+    "/api/registry/policypacks/{source}/{publisher}/{name}/versions/{version}": {
+      "delete": {
+        "description": "Deletes a specific version of a policy pack from the registry. The policy pack version is identified by its source (currently only 'private'), publisher organization, name, and semantic version string. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the specified policy pack version does not exist.",
+        "operationId": "DeleteRegistryPolicyPackVersion",
+        "parameters": [
+          {
+            "description": "The policy pack source: 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the policy pack",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The policy pack name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string of the policy pack version to delete",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Policy pack not found"
+          }
+        },
+        "summary": "DeleteRegistryPolicyPackVersion",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      },
+      "get": {
+        "description": "Retrieves detailed information about a specific version of a policy pack, including the individual policy definitions. The policy pack is identified by its source (currently only 'private'), publisher organization, and name. The version parameter accepts either a specific semantic version string or the special value 'latest' to retrieve the most recently published version. The response includes the policy pack metadata and an optional list of policies, where each policy includes its configuration schema and enforcement rules. Returns 404 if the specified policy pack does not exist.",
+        "operationId": "GetPolicyPackVersionForRegistry",
+        "parameters": [
+          {
+            "description": "The policy pack source: 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the policy pack",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The policy pack name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetRegistryPolicyPackVersionResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Policy Pack"
+          }
+        },
+        "summary": "GetPolicyPackVersion",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      }
+    },
+    "/api/registry/policypacks/{source}/{publisher}/{name}/versions/{version}/complete": {
+      "post": {
+        "description": "Finalizes the second step of the two-phase policy pack version publish workflow. After initiating a publish with PostPublishPolicyPackVersion, call this endpoint with the policy pack source, publisher, name, and version to complete the publish and make the version available in the registry. Requires the RegistryPublish permission on the publisher organization. Returns 404 if the publish operation is not found.",
+        "operationId": "PostPublishPolicyPackVersionCompleteForRegistry",
+        "parameters": [
+          {
+            "description": "The policy pack source: 'private'",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the policy pack",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The policy pack name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string of the policy pack version to complete",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Publish operation not found"
+          }
+        },
+        "summary": "PostPublishPolicyPackVersionComplete",
+        "tags": [
+          "Registry",
+          "PolicyPacks"
+        ]
+      }
+    },
     "/api/registry/templates": {
       "get": {
         "description": "Lists registry-backed templates with optional filtering, search, and pagination. This endpoint returns only registry-backed templates and does not include VCS-backed templates (those sourced from GitHub or GitLab repositories). No authentication is required. Results can be filtered by template name and owning organization (orgLogin). The search parameter performs case-insensitive partial matching against the template name, display name, description, metadata values, and runtime language. Results are paginated with a default limit of 100 per page; use the continuationToken from the response to retrieve subsequent pages. Each entry in the response includes the template's name, publisher, source, display name, description, runtime, language, readme URL, download URL, visibility, and updated timestamp.",
@@ -48401,6 +55053,277 @@
         ]
       }
     },
+    "/api/registry/terraform-modules": {
+      "get": {
+        "description": "Browses Terraform modules hosted in the Pulumi Cloud registry. By default it returns the public modules unioned with the private modules in every namespace (organization) the caller can access; access is evaluated per module, so an unauthenticated caller sees only public modules. The optional 'namespace' query parameter narrows results to a single organization the caller belongs to (a namespace the caller cannot access yields an empty page rather than leaking existence). Results can be filtered by module name prefix and are paginated with a default limit of 100 per page; use the continuationToken from the response to retrieve subsequent pages. Each entry includes the module's name, publisher, source, system, latest version, and updated timestamp. This endpoint is in Preview and its shape may change.",
+        "operationId": "ListTerraformModules",
+        "parameters": [
+          {
+            "description": "Pagination token for retrieving the next page of results",
+            "in": "query",
+            "name": "continuationToken",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of results to return (default: 100)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by module name prefix",
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional filter to a single namespace (organization login); defaults to every namespace the caller can access",
+            "in": "query",
+            "name": "namespace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTerraformModulesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          }
+        },
+        "summary": "ListTerraformModules",
+        "tags": [
+          "Registry"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/registry/terraform-modules/{source}/{publisher}/{name}/versions": {
+      "get": {
+        "description": "Lists all versions of a Terraform module, ordered by version descending (latest first). The module is identified by its registry source, publisher organization, and the module name and provider system joined by a hyphen (e.g. 'vpc-aws'). Returns 404 if the module does not exist. This endpoint is in Preview and its shape may change.",
+        "operationId": "ListTerraformModuleVersions",
+        "parameters": [
+          {
+            "description": "The registry source name (e.g. 'private' for private modules, or the interim public source such as 'pulumi')",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the module",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The module name and provider system joined by a hyphen (e.g. 'vpc-aws'); split on the last hyphen",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pagination token for retrieving the next page of results",
+            "in": "query",
+            "name": "continuationToken",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of results to return (default: 100)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTerraformModuleVersionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          },
+          "404": {
+            "description": "terraform module"
+          }
+        },
+        "summary": "ListTerraformModuleVersions",
+        "tags": [
+          "Registry"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
+    "/api/registry/terraform-modules/{source}/{publisher}/{name}/versions/{version}": {
+      "delete": {
+        "description": "Removes a specific version of a Terraform module from the registry. The module is identified by its registry source, publisher organization, and the module name and provider system joined by a hyphen (e.g. 'vpc-aws'). If this is the last remaining version, the 'force' query parameter must be set to true; doing so also deletes the module itself. This endpoint is in Preview and its shape may change.",
+        "operationId": "DeleteTerraformModuleVersion",
+        "parameters": [
+          {
+            "description": "The registry source name (e.g. 'private' for private modules, or the interim public source such as 'pulumi')",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the module",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The module name and provider system joined by a hyphen (e.g. 'vpc-aws'); split on the last hyphen",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string of the module version to delete",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "When true, allows deletion of the final remaining module version (and the module)",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "invalid query parameter"
+          }
+        },
+        "summary": "DeleteTerraformModuleVersion",
+        "tags": [
+          "Registry"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      },
+      "get": {
+        "description": "Retrieves the detail for a specific version of a Terraform module, including the README and the inputs, outputs, and provider requirements parsed from the tarball at publish time. The module is identified by its registry source, publisher organization, and the module name and provider system joined by a hyphen (e.g. 'vpc-aws'). The version may be a semantic version string or 'latest'. Returns 404 if the module version does not exist. This endpoint is in Preview and its shape may change.",
+        "operationId": "GetTerraformModuleVersion",
+        "parameters": [
+          {
+            "description": "The registry source name (e.g. 'private' for private modules, or the interim public source such as 'pulumi')",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization that owns the module",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The module name and provider system joined by a hyphen (e.g. 'vpc-aws'); split on the last hyphen",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Semantic version string or 'latest'",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTerraformModuleResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "terraform module version"
+          }
+        },
+        "summary": "GetTerraformModuleVersion",
+        "tags": [
+          "Registry"
+        ],
+        "x-pulumi-route-property": {
+          "Visibility": "Preview"
+        }
+      }
+    },
     "/api/stacks/{orgName}/{projectName}": {
       "head": {
         "description": "Checks whether a project exists within an organization. Returns 200 with the project name if it exists, or 404 if not found. This is a lightweight existence check useful for validating project names before creating stacks or performing other operations.",
@@ -48446,7 +55369,7 @@
         ]
       },
       "post": {
-        "description": "Creates a new stack within a project in the organization. A stack is an isolated, independently configurable instance of a Pulumi program, typically representing a deployment environment (e.g., development, staging, production). The stack name must be unique within the project.",
+        "description": "Creates a new stack within a project in the organization. If the project does not exist, it will be created. A stack is an isolated, independently configurable instance of a Pulumi program, typically representing a deployment environment (e.g., development, staging, production). The stack name must be unique within the project.\n\nThe optional `config` object supports:\n- `environment`: reference to an ESC environment for storing stack configuration (must not already exist)\n- `secretsProvider`: the secrets provider for the stack\n- `encryptedKey`: KMS-encrypted ciphertext for the data key (cloud-based secrets providers only)\n- `encryptionSalt`: base64-encoded encryption salt (passphrase-based secrets providers only)",
         "operationId": "CreateStack",
         "parameters": [
           {
@@ -48471,6 +55394,17 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "stackName": "production",
+                "tags": {
+                  "environment": "prod",
+                  "owner": "platform"
+                },
+                "teams": [
+                  "platform",
+                  "sre"
+                ]
+              },
               "schema": {
                 "$ref": "#/components/schemas/AppCreateStackRequest"
               }
@@ -48551,7 +55485,7 @@
         ]
       },
       "get": {
-        "description": "Retrieves detailed information about a specific stack, including its organization, project, and stack name, the current version number, all associated tags, any active update operations (with the operation kind, author, and start time), and the active update UUID. This is the primary endpoint for inspecting the current state and metadata of a stack.",
+        "description": "Retrieves detailed information about a specific stack: its organization, project, and stack name, the current version number, all associated tags, the UUID of the most recent update on the stack (either completed or in-progress), and — when an operation is currently in flight — a `currentOperation` summary with that operation's kind, author, and start time. This is the primary endpoint for inspecting the current state and metadata of a stack.",
         "operationId": "GetStack",
         "parameters": [
           {
@@ -48586,6 +55520,19 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "activeUpdate": "d333a711-4aa0-402f-be6d-72af9665fc37",
+                  "currentOperation": {
+                    "author": "jane@acme-corp.com",
+                    "kind": "update",
+                    "started": 1720000000
+                  },
+                  "id": "acme-corp/website/production",
+                  "orgName": "acme-corp",
+                  "projectName": "website",
+                  "stackName": "production",
+                  "version": 42
+                },
                 "schema": {
                   "$ref": "#/components/schemas/AppStack"
                 }
@@ -49016,7 +55963,11 @@
         "summary": "ListStackPermissions",
         "tags": [
           "Stacks"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "Visibility": "Public"
+        }
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/collaborators/{userName}": {
@@ -49077,7 +56028,7 @@
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/config": {
       "delete": {
-        "description": "Removes the service-managed configuration for a stack, including the secrets provider settings, encrypted key, encryption salt, and ESC environment reference. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. Pulumi.[stack].yaml). Deleting the config causes the CLI to fall back to the local config file. Returns 204 with no content on success.",
+        "description": "Removes the service-managed configuration for a stack — the ESC environment reference that points the stack at a service-backed configuration. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. Pulumi.[stack].yaml). Deleting the config causes the CLI to fall back to the local config file. Returns 204 with no content on success.",
         "operationId": "DeleteStackConfig",
         "parameters": [
           {
@@ -49115,11 +56066,12 @@
         },
         "summary": "DeleteStackConfig",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackConfig"
         ]
       },
       "get": {
-        "description": "Retrieves the service-managed configuration for a stack. The response includes the ESC environment reference, secrets provider type, encrypted key, and encryption salt. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. Pulumi.[stack].yaml). Returns 404 if no service-managed configuration exists for the stack.",
+        "description": "Retrieves the service-managed configuration for a stack. The response includes the ESC environment reference that points the stack at a service-backed configuration. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. Pulumi.[stack].yaml). Returns 404 if no service-managed configuration exists for the stack. The 'secretsProvider', 'encryptedKey', and 'encryptionSalt' fields are deprecated and should be ignored by new callers; they may carry legacy values from existing rows but no longer reflect any service behavior.",
         "operationId": "GetStackConfig",
         "parameters": [
           {
@@ -49167,11 +56119,12 @@
         },
         "summary": "GetStackConfig",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackConfig"
         ]
       },
       "put": {
-        "description": "Updates the service-managed configuration for a stack. The request body may include the ESC environment reference, secrets provider type, encrypted key, and encryption salt. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. Pulumi.[stack].yaml). Returns the updated configuration object. Returns 400 if the environment reference is invalid or not found.",
+        "description": "Updates the service-managed configuration for a stack. The request body sets the ESC environment reference that points the stack at a service-backed configuration. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. Pulumi.[stack].yaml). Returns the updated configuration object. Returns 400 if the environment reference is invalid or not found. The 'secretsProvider', 'encryptedKey', and 'encryptionSalt' fields are deprecated; new callers should omit them.",
         "operationId": "UpdateStackConfig",
         "parameters": [
           {
@@ -49229,7 +56182,8 @@
         },
         "summary": "UpdateStackConfig",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackConfig"
         ]
       }
     },
@@ -49496,7 +56450,7 @@
         ]
       },
       "post": {
-        "description": "Initiates a new Pulumi Deployments execution for a stack. Pulumi Deployments is a managed service that executes Pulumi operations (update, preview, refresh, or destroy) in a secure, hosted environment. The request body must include an 'operation' field specifying the Pulumi operation to perform. When 'inheritSettings' is true (the default), the deployment merges request settings with the stack's saved deployment settings, with request settings taking precedence. The stack must already exist. The deployment is queued and returns a 202 Accepted response with the deployment ID. Settings include source context (git repo, branch, directory), operation context (environment variables, pre-run commands, OIDC configuration), executor context, GitHub integration settings, and cache options.\n\nThis is v2 with breaking changes from CreateAPIDeploymentHandler: inheritSettings defaults to true, and operation is a required top-level field and no longer valid as part of operationContext.",
+        "description": "Initiates a new Pulumi Deployments execution for a stack. Pulumi Deployments is a managed service that executes Pulumi operations (update, preview, refresh, or destroy) in a secure, hosted environment.\n\n**Important:** The stack must already exist before a deployment can be created for it.\n\nThe `operation` field is required and accepts: `update`, `preview`, `refresh`, or `destroy`. Three usage modes are supported:\n1. **Stack settings only:** Send `{\"operation\": \"update\"}` to use the stack's saved deployment settings.\n2. **Merged settings:** Include partial settings in the request body alongside `operation`. When `inheritSettings` is true (the default), request settings are merged with saved stack settings, with request values taking precedence.\n3. **Request settings only:** Set `inheritSettings` to false and provide all settings in the request body.\n\nSettings include source context (git repo, branch, directory), operation context (environment variables, pre-run commands, OIDC configuration), executor context, GitHub integration settings, and cache options.\n\nThis is v2 with breaking changes from CreateAPIDeploymentHandler: inheritSettings defaults to true, and operation is a required top-level field and no longer valid as part of operationContext.",
         "operationId": "CreateAPIDeploymentHandlerV2",
         "parameters": [
           {
@@ -49614,76 +56568,6 @@
         ]
       }
     },
-    "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/cache/url": {
-      "post": {
-        "description": "Returns a presigned URL for saving or restoring the Pulumi Deployments dependency cache. The cache stores build artifacts and dependencies between deployment runs to speed up execution. The request body must specify a method (PUT to upload a cache archive, or GET to download one) and a non-empty cache key identifying the cached content. The returned presigned URL can be used directly for the corresponding HTTP operation against the object store without additional authentication.",
-        "operationId": "GetPresignedCacheURL",
-        "parameters": [
-          {
-            "description": "The organization name",
-            "in": "path",
-            "name": "orgName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The project name",
-            "in": "path",
-            "name": "projectName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The stack name",
-            "in": "path",
-            "name": "stackName",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CacheURLRequest"
-              }
-            }
-          },
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CacheURLResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Invalid method. Must be PUT or GET. or Invalid key. Must be non-empty."
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Stack"
-          }
-        },
-        "summary": "GetPresignedCacheURL",
-        "tags": [
-          "Deployments"
-        ]
-      }
-    },
     "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/drift/schedules": {
       "post": {
         "description": "Creates a drift detection schedule for a stack using Pulumi Deployments. Drift detection identifies divergence between the declared infrastructure state in your Pulumi program and the actual state of resources in the cloud provider. The 'scheduleCron' field accepts a cron expression defining when drift detection should run (e.g. '0 */4 * * *' for every 4 hours). When 'autoRemediate' is set to true, a remediation update is automatically triggered to bring resources back into alignment with the declared state whenever drift is detected. Auto-remediation requires a Business Critical subscription. The stack must have deployment settings configured before a drift schedule can be created.",
@@ -49750,7 +56634,8 @@
         },
         "summary": "CreateScheduledDriftDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -49829,13 +56714,14 @@
         },
         "summary": "UpdateScheduledDriftDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/metadata": {
       "get": {
-        "description": "Returns metadata about the Pulumi Deployments state for a specific stack. The response includes the overall pause status, whether the stack itself is paused, and whether the organization-level pause is in effect. This is useful for determining whether new deployments will be processed or held in the queue.",
+        "description": "Returns metadata about the Pulumi Deployments state for a specific stack. The response distinguishes the source of any pause:\n\n- `paused`: overall pause status (true if either stack or org is paused)\n- `stackPaused`: whether the stack itself is paused\n- `organizationPaused`: whether the containing organization is paused\n\nThis is useful for determining whether new deployments will be processed or held in the queue.",
         "operationId": "StackDeploymentsMetadata",
         "parameters": [
           {
@@ -50028,7 +56914,8 @@
         },
         "summary": "ListScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       },
       "post": {
@@ -50090,13 +56977,14 @@
         },
         "summary": "CreateScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/schedules/{scheduleID}": {
       "delete": {
-        "description": "Permanently deletes a scheduled deployment action from a stack. This removes the schedule configuration entirely and cannot be undone. The schedule will no longer execute any future runs. This endpoint is used for all schedule types (custom, drift detection, and TTL). To temporarily stop a schedule without deleting it, use the pause endpoint instead.",
+        "description": "Permanently deletes a scheduled deployment action from a stack. This removes the schedule configuration entirely and cannot be undone. The schedule will no longer execute any future runs. This endpoint is used for all schedule types (custom, drift detection, and TTL). To temporarily stop a schedule without deleting it, use the pause endpoint instead. The delete is idempotent: deleting a schedule that no longer exists on the stack — for example a one-time TTL schedule that already fired and was removed automatically — succeeds and returns 200 rather than 404.",
         "operationId": "DeleteScheduledDeployment",
         "parameters": [
           {
@@ -50141,12 +57029,13 @@
             "description": "OK"
           },
           "404": {
-            "description": "ScheduledDeployment"
+            "description": "Stack"
           }
         },
         "summary": "DeleteScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       },
       "get": {
@@ -50207,7 +57096,8 @@
         },
         "summary": "ReadScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       },
       "post": {
@@ -50281,7 +57171,8 @@
         },
         "summary": "UpdateScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -50344,7 +57235,8 @@
         },
         "summary": "ListScheduledDeploymentHistory",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -50400,7 +57292,8 @@
         },
         "summary": "PauseScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -50456,7 +57349,8 @@
         },
         "summary": "ResumeScheduledDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -50634,6 +57528,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "description": "Fully replaces the Pulumi Deployments settings for a stack. Unlike the PATCH endpoint (PatchDeploymentSettings) which merges changes, this endpoint replaces all settings with the provided values. Any previously configured settings not included in the request body will be removed. Settings include source context (git repository URL, branch, directory), operation context (environment variables, pre-run commands, OIDC configuration), executor context, GitHub integration settings, and cache options. Requires a Team Growth or higher subscription. Cannot be used to configure Pulumi Deployments for Terraform stacks.",
         "operationId": "ReplaceDeploymentSettings",
         "parameters": [
@@ -50699,11 +57594,17 @@
         "summary": "ReplaceDeploymentSettings",
         "tags": [
           "Deployments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PatchDeploymentSettings",
+          "Visibility": "Public"
+        }
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/settings/encrypt": {
       "post": {
+        "deprecated": true,
         "description": "Encrypts a plaintext secret value for secure storage in Pulumi Deployments settings. Use this endpoint to encrypt sensitive values such as cloud provider credentials, API keys, or other secrets before including them in deployment settings (e.g. as environment variables in operationContext). The encrypted value can then be safely stored in the deployment settings and will be decrypted at deployment execution time. The request body must contain a non-empty plaintext value to encrypt.",
         "operationId": "EncryptDeploymentSettingsSecret",
         "parameters": [
@@ -50766,7 +57667,12 @@
         "summary": "EncryptDeploymentSettingsSecret",
         "tags": [
           "Deployments"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "SupersededBy": "PatchDeploymentSettings",
+          "Visibility": "Public"
+        }
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/ttl/schedules": {
@@ -50832,7 +57738,8 @@
         },
         "summary": "CreateScheduledTTLDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -50908,7 +57815,8 @@
         },
         "summary": "UpdateScheduledTTLDeployment",
         "tags": [
-          "Deployments"
+          "Deployments",
+          "Schedules"
         ]
       }
     },
@@ -51040,7 +57948,7 @@
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/deployments/{deploymentId}/cancel": {
       "post": {
-        "description": "Terminates an in-progress Pulumi Deployments execution for a specific stack. If the deployment is currently running, it is stopped immediately. If the deployment is queued but has not yet started, it is removed from the queue. Warning: cancellation may leave the stack in an inconsistent state if interrupted during a Pulumi operation execution.\n\nNote that this serves two endpoints:\n- /{orgName}/{projectName}/{stackName}/deployments/{deploymentId}/cancel\n- /admin/deployments/{deploymentId}/cancel\n\nThe former requires that the requesting user has stack deployment create permissions. The latter requires that the requesting user is a site administrator.",
+        "description": "Terminates an in-progress Pulumi Deployments execution for a specific stack. If the deployment is currently running, it is stopped immediately. If the deployment is queued but has not yet started, it is removed from the queue.\n\n**Warning:** Canceling a deployment is a dangerous action and may leave the stack in an inconsistent state if the deployment is canceled during the execution of a Pulumi operation.\n\nNote that this serves two endpoints:\n- /{orgName}/{projectName}/{stackName}/deployments/{deploymentId}/cancel\n- /admin/deployments/{deploymentId}/cancel\n\nThe former requires that the requesting user has stack deployment create permissions. The latter requires that the requesting user is a site administrator.",
         "operationId": "CancelDeployment",
         "parameters": [
           {
@@ -51918,7 +58826,8 @@
         },
         "summary": "GetEngineEvents",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackUpdates"
         ]
       },
       "post": {
@@ -52627,7 +59536,7 @@
     "/api/stacks/{orgName}/{projectName}/{stackName}/hooks": {
       "get": {
         "description": "Returns all webhooks configured for the specified stack. Each webhook in the response includes its name, display name, payload URL, format, filters, and active status.",
-        "operationId": "ListWebhooks_stacks",
+        "operationId": "ListStackWebhooks",
         "parameters": [
           {
             "description": "The organization name",
@@ -52672,14 +59581,15 @@
             "description": "successful operation"
           }
         },
-        "summary": "ListWebhooks",
+        "summary": "ListStackWebhooks",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       },
       "post": {
-        "description": "Creates a new webhook for the specified stack. The request body must include the webhook name, payload URL, and format. Optional fields include display name, groups, filters, and active status. Returns 409 if a webhook with the same name already exists. Returns 400 if the organization or stack name in the request body does not match the URL path parameters, or if any configuration values are invalid.",
-        "operationId": "CreateWebhook_stacks",
+        "description": "Creates a new webhook for the specified stack. The request body must include the webhook name, payload URL, and format.\n\nThe `format` field accepts: `raw` (default), `slack`, `ms_teams`, or `pulumi_deployments`.\n\nThe `filters` field accepts a list of event types to subscribe to. See the [webhook event filtering documentation](https://www.pulumi.com/docs/pulumi-cloud/webhooks/#event-filtering) for available filters.\n\nThe optional `secret` field sets the HMAC key for signature verification. See the [webhook headers documentation](https://www.pulumi.com/docs/pulumi-cloud/webhooks/#headers) for details.\n\nReturns 409 if a webhook with the same name already exists. Returns 400 if the organization or stack name in the request body does not match the URL path parameters.",
+        "operationId": "CreateStackWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -52737,16 +59647,17 @@
             "description": "Webhook with name {name} already exists."
           }
         },
-        "summary": "CreateWebhook",
+        "summary": "CreateStackWebhook",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/hooks/{hookName}": {
       "delete": {
         "description": "Deletes a webhook from the specified stack. Returns 204 with no content on success.",
-        "operationId": "DeleteWebhook_stacks",
+        "operationId": "DeleteStackWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -52790,14 +59701,15 @@
             "description": "No Content"
           }
         },
-        "summary": "DeleteWebhook",
+        "summary": "DeleteStackWebhook",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       },
       "get": {
         "description": "Returns the details of a single webhook identified by its name, including its configuration, filters, groups, and active status. Returns 404 if the webhook does not exist.",
-        "operationId": "GetWebhook_stacks",
+        "operationId": "GetStackWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -52851,14 +59763,15 @@
             "description": "Webhook"
           }
         },
-        "summary": "GetWebhook",
+        "summary": "GetStackWebhook",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       },
       "patch": {
         "description": "Updates an existing webhook's configuration. Supports modifying the display name, payload URL, format, groups, filters, and active status. The 'pulumi_deployments' format can only be used on stack or environment webhooks. Returns 404 if the webhook does not exist.",
-        "operationId": "UpdateWebhook_stacks",
+        "operationId": "UpdateStackWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -52925,16 +59838,17 @@
             "description": "Webhook"
           }
         },
-        "summary": "UpdateWebhook",
+        "summary": "UpdateStackWebhook",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/hooks/{hookName}/deliveries": {
       "get": {
         "description": "Returns the recent delivery history for a specific webhook. Each delivery includes the timestamp, HTTP status code, request and response details, and whether the delivery was successful.",
-        "operationId": "GetWebhookDeliveries_stacks",
+        "operationId": "GetStackWebhookDeliveries",
         "parameters": [
           {
             "description": "The organization name",
@@ -52988,16 +59902,17 @@
             "description": "successful operation"
           }
         },
-        "summary": "GetWebhookDeliveries",
+        "summary": "GetStackWebhookDeliveries",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/hooks/{hookName}/deliveries/{event}/redeliver": {
       "post": {
         "description": "Triggers the Pulumi Service to redeliver a specific event to a webhook. This is useful for resending an event that the webhook endpoint failed to process on the initial delivery attempt. Returns the delivery result with HTTP status and response details. Returns 404 if the webhook or event does not exist.",
-        "operationId": "RedeliverWebhookEvent_stacks",
+        "operationId": "RedeliverStackWebhookEvent",
         "parameters": [
           {
             "description": "The organization name",
@@ -53060,16 +59975,17 @@
             "description": "Webhook or WebhookEvent"
           }
         },
-        "summary": "RedeliverWebhookEvent",
+        "summary": "RedeliverStackWebhookEvent",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       }
     },
     "/api/stacks/{orgName}/{projectName}/{stackName}/hooks/{hookName}/ping": {
       "post": {
         "description": "Issues a test ping event to the specified webhook to verify it is properly configured and reachable. Unlike normal webhook deliveries, this bypasses the message queue and sends the request directly to the webhook endpoint. The response includes the delivery result with HTTP status and response details. Returns 404 if the webhook does not exist.",
-        "operationId": "PingWebhook_stacks",
+        "operationId": "PingStackWebhook",
         "parameters": [
           {
             "description": "The organization name",
@@ -53123,9 +60039,10 @@
             "description": "Webhook"
           }
         },
-        "summary": "PingWebhook",
+        "summary": "PingStackWebhook",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "Webhooks"
         ]
       }
     },
@@ -53308,6 +60225,68 @@
         ]
       }
     },
+    "/api/stacks/{orgName}/{projectName}/{stackName}/ownership": {
+      "post": {
+        "description": "Changes the ownership of the specified stack to the provided user. Returns the identity of the previous owner.",
+        "operationId": "ReassignStackOwnership",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The project name",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The stack name",
+            "in": "path",
+            "name": "stackName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInfo"
+              }
+            }
+          },
+          "description": "The new owner's identity",
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserInfo"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ReassignStackOwnership",
+        "tags": [
+          "Stacks"
+        ]
+      }
+    },
     "/api/stacks/{orgName}/{projectName}/{stackName}/policygroups": {
       "get": {
         "description": "Returns the list of policy groups that include the specified stack. Policy groups define which policy packs are enforced on a set of stacks. The response includes each group's name, the stacks it applies to, and the policy packs configured within it.",
@@ -53355,7 +60334,8 @@
         },
         "summary": "GetStackPolicyGroups",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackPolicy"
         ]
       }
     },
@@ -53400,7 +60380,11 @@
                 "audit",
                 "preventative"
               ],
-              "type": "string"
+              "type": "string",
+              "x-pulumi-model-property": {
+                "enumComments": "PolicyGroupMode represents the enforcement mode for a policy group",
+                "enumTypeName": "PolicyGroupMode"
+              }
             }
           }
         ],
@@ -53421,7 +60405,8 @@
         },
         "summary": "GetStackPolicyPacks",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackPolicy"
         ]
       }
     },
@@ -55756,7 +62741,8 @@
         },
         "summary": "UpdateStackTags",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackTags"
         ]
       },
       "post": {
@@ -55811,7 +62797,8 @@
         },
         "summary": "AddStackTag",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackTags"
         ]
       }
     },
@@ -55870,7 +62857,8 @@
         },
         "summary": "DeleteStackTag",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackTags"
         ]
       },
       "patch": {
@@ -55937,7 +62925,8 @@
         },
         "summary": "UpdateStackTag",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackTags"
         ]
       }
     },
@@ -56177,7 +63166,8 @@
         },
         "summary": "GetUpdateStatusForUpdate",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackUpdates"
         ]
       },
       "post": {
@@ -57097,7 +64087,7 @@
             }
           },
           {
-            "description": "Number of results per page (must be >= 1 when page > 0)",
+            "description": "Number of results per page. Must be >= 0; defaults to 10. Ignored when page is 0, which returns all results.",
             "in": "query",
             "name": "pageSize",
             "schema": {
@@ -57123,7 +64113,8 @@
         },
         "summary": "GetStackUpdates",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackUpdates"
         ]
       }
     },
@@ -57257,7 +64248,8 @@
         },
         "summary": "GetLatestStackPreviews",
         "tags": [
-          "Stacks"
+          "Stacks",
+          "StackUpdates"
         ]
       }
     },
@@ -57597,6 +64589,57 @@
         ]
       }
     },
+    "/api/stacks/{orgName}/{projectName}/{stackName}/upstreamreferences": {
+      "get": {
+        "description": "Returns all stacks that the specified stack references as dependencies in its Pulumi program (via StackReference). This is useful for understanding what external stacks a given stack depends on and consumes outputs from. The response includes each referenced stack's organization, project, name, and version.",
+        "operationId": "ListUpstreamStackReferences",
+        "parameters": [
+          {
+            "description": "The organization name",
+            "in": "path",
+            "name": "orgName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The project name",
+            "in": "path",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The stack name",
+            "in": "path",
+            "name": "stackName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDownstreamStackReferencesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "ListUpstreamStackReferences",
+        "tags": [
+          "Stacks"
+        ]
+      }
+    },
     "/api/stacks/{orgName}/{projectName}/{stackName}/workflow": {
       "post": {
         "description": "Generates a customized CI/CD workflow template for the specified stack. The request body must specify the target CI system (e.g. GitHub Actions, GitLab CI). The generated template is tailored to the stack's runtime and configuration. Returns 400 if the CI system is not specified or the stack does not have a runtime tag. Returns 404 if no matching workflow template is found.",
@@ -57666,7 +64709,7 @@
     },
     "/api/user": {
       "get": {
-        "description": "GetCurrentUser returns the current authenticated user's info.",
+        "description": "Returns the authenticated user's profile information, including login name, display name, email, avatar URL, and organization memberships.",
         "operationId": "GetCurrentUser",
         "responses": {
           "200": {
@@ -57683,42 +64726,6 @@
         "summary": "GetCurrentUser",
         "tags": [
           "Users"
-        ]
-      }
-    },
-    "/api/user/ai/usage": {
-      "get": {
-        "description": "Returns the number of messages sent by the user by counting\nthe number of messages in the ConversationMessages table, using optional lookback duration",
-        "operationId": "GetSentMessageCountForUser",
-        "parameters": [
-          {
-            "description": "Duration in seconds to look back for messages. Must be positive if provided.",
-            "in": "query",
-            "name": "lookbackDuration",
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetMessageCountResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "lookbackDuration must be positive"
-          }
-        },
-        "summary": "GetSentMessageCountForUser",
-        "tags": [
-          "AI"
         ]
       }
     },
@@ -57784,7 +64791,11 @@
         "summary": "GetGroupsForGitLabApp",
         "tags": [
           "Users"
-        ]
+        ],
+        "x-pulumi-route-property": {
+          "Deprecated": true,
+          "Visibility": "Public"
+        }
       }
     },
     "/api/user/organizations/default": {
@@ -57987,7 +64998,7 @@
     },
     "/api/user/tokens": {
       "get": {
-        "description": "Returns all personal access tokens for the authenticated user. Web-session generated tokens (type 'web') are excluded from the results. Each token in the response includes its ID, description, and lastUsed timestamp. Use the filter query parameter to search tokens by name or description.",
+        "description": "Returns the access tokens currently bound to the authenticated user: personal access tokens (Bearer-usable) and refresh tokens issued during agent signup (exchange-only at POST /api/oauth/token; 401 if presented as Bearer). Web-session tokens are excluded. Use the filter query parameter to search tokens by name or description. Revoke any entry via DELETE /api/user/tokens/{tokenId}, which is type-agnostic.",
         "operationId": "ListPersonalTokens",
         "parameters": [
           {
@@ -58013,7 +65024,8 @@
         },
         "summary": "ListPersonalTokens",
         "tags": [
-          "Users"
+          "Users",
+          "AccessTokens"
         ]
       },
       "post": {
@@ -58053,7 +65065,8 @@
         },
         "summary": "CreatePersonalToken",
         "tags": [
-          "Users"
+          "Users",
+          "AccessTokens"
         ]
       }
     },
@@ -58082,7 +65095,8 @@
         },
         "summary": "DeletePersonalToken",
         "tags": [
-          "Users"
+          "Users",
+          "AccessTokens"
         ]
       }
     },
@@ -58212,7 +65226,19 @@
       "name": "AI Agents"
     },
     {
+      "name": "AccessTokens"
+    },
+    {
+      "name": "AuditLogs"
+    },
+    {
       "name": "CloudSetup"
+    },
+    {
+      "name": "DataExport"
+    },
+    {
+      "name": "DeploymentRunners"
     },
     {
       "name": "Deployments"
@@ -58224,16 +65250,64 @@
       "name": "Insights"
     },
     {
+      "name": "InsightsAccounts"
+    },
+    {
+      "name": "Invites"
+    },
+    {
       "name": "Miscellaneous"
     },
     {
+      "name": "Neo"
+    },
+    {
+      "name": "OAuthTokenExchange"
+    },
+    {
+      "name": "OidcIssuers"
+    },
+    {
       "name": "Organizations"
+    },
+    {
+      "name": "PolicyGroups"
+    },
+    {
+      "name": "PolicyPacks"
+    },
+    {
+      "name": "PolicyResults"
     },
     {
       "name": "Registry"
     },
     {
       "name": "RegistryPreview"
+    },
+    {
+      "name": "ResourceSearch"
+    },
+    {
+      "name": "ResourcesUnderManagement"
+    },
+    {
+      "name": "Schedules"
+    },
+    {
+      "name": "Services"
+    },
+    {
+      "name": "StackConfig"
+    },
+    {
+      "name": "StackPolicy"
+    },
+    {
+      "name": "StackTags"
+    },
+    {
+      "name": "StackUpdates"
     },
     {
       "name": "Stacks"
@@ -58243,6 +65317,9 @@
     },
     {
       "name": "VCS Integrations"
+    },
+    {
+      "name": "Webhooks"
     },
     {
       "name": "Workflows"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -387,6 +387,9 @@ mod tests {
     /// Helper to create a client from the .env PAT token.
     /// Returns None if no token is available (skips test).
     fn integration_client() -> Option<PulumiClient> {
+        // Hold the env lock so parallel unit tests that temporarily set
+        // fake PULUMI_ACCESS_TOKEN values can't leak into this client.
+        let _lock = ENV_MUTEX.lock().unwrap();
         // Try loading from .env file first
         if let Ok(content) = std::fs::read_to_string(".env") {
             let token = content.lines().next().unwrap_or("").trim();

--- a/src/api/convert.rs
+++ b/src/api/convert.rs
@@ -248,6 +248,7 @@ mod tests {
             .referrer_metadata(referrer_metadata)
             .settings(settings)
             .tags(HashMap::new())
+            .owned_by(make_user_info("owner"))
             .try_into()
             .expect("valid OrgEnvironment")
     }
@@ -279,6 +280,8 @@ mod tests {
             .entities(entities)
             .approval_mode(gen::AgentTaskApprovalMode::Manual)
             .plan_mode(false)
+            .task_type(gen::AgentTaskTaskType::Sync)
+            .tokens_used(0_i64)
             .try_into()
             .expect("valid AgentTask")
     }
@@ -543,6 +546,8 @@ mod tests {
             .shared_at(Some(now))
             .approval_mode(gen::AgentTaskApprovalMode::Manual)
             .plan_mode(false)
+            .task_type(gen::AgentTaskTaskType::Sync)
+            .tokens_used(0_i64)
             .try_into()
             .expect("valid AgentTask");
         let task: domain::NeoTask = gen_task.into();
@@ -867,6 +872,8 @@ mod tests {
             .entities(Vec::<gen::AgentEntity>::new())
             .approval_mode(gen::AgentTaskApprovalMode::Manual)
             .plan_mode(true)
+            .task_type(gen::AgentTaskTaskType::Sync)
+            .tokens_used(0_i64)
             .try_into()
             .expect("valid AgentTask");
         let task: domain::NeoTask = gen_task.into();


### PR DESCRIPTION
## What

Refreshes `openapi/pulumi-spec.json` via `cargo xtask update-spec` after merging the six open dependabot PRs (#76, #78, #79, #81, #83, #84), and adapts the code to the new spec.

## Spec changes affecting our kept subset

- **AgentTask**: `taskType` and `tokensUsed` are now required; the list endpoint gains `sortBy`/`sortDirection`/`taskType` query params (new enums `AgentTaskSortField`, `AgentTaskSortDirection`, `AgentTaskType`)
- **OrgEnvironment**: `ownedBy` (UserInfo) is now required
- **resources summary**: `granularity` is now a required enum (`UsageSummaryTimeUnit`); our `"daily"` argument converts via `TryInto`, so no client change needed
- **org services**: gains `continuationToken`/`maxResults` pagination query params (additive)
- **registry packages/templates**: marked deprecated upstream (superseded by `ListPackages`/`ListTemplates`) — still present and functional
- `User.tokenInfo` and `ListServicesResponse.continuationToken` are no longer marked required upstream, so those two `build.rs` patches are now harmless no-ops; the `AgentTask.entities` patch is still needed

## Code changes

- `src/api/convert.rs`: test fixtures supply the newly required builder fields (`task_type`, `tokens_used`, `owned_by`)
- `src/api/client.rs`: `integration_client()` now holds `ENV_MUTEX`, fixing a pre-existing race where parallel unit tests that temporarily set fake `PULUMI_ACCESS_TOKEN` values leaked into integration tests and caused flaky 401 failures

## Caveat

`ownedBy`, `taskType`, `tokensUsed` being *required* is spec-side only — if the live API ever omits them for old records, deserialization of those responses fails; the existing `patch_nullable_fields` mechanism in `build.rs` is the fix if that shows up (couldn't verify against the live API from this environment: no token).

## Verification

- `cargo test`: 81 passed, 0 failed — three consecutive runs (race gone)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean

https://claude.ai/code/session_01Eq4ckheD9gvhNz6DkYbqJv