### PR TITLE
fix(dashboard): exact fast resource count, full stack pagination, tile spinners

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -489,6 +489,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn integration_count_resources() {
+        let Some(client) = integration_client() else {
+            eprintln!("Skipping integration test: no PULUMI_ACCESS_TOKEN");
+            return;
+        };
+
+        match client.count_resources(None).await {
+            Ok(count) => {
+                eprintln!("integration_count_resources: {} resources", count);
+                assert!(count >= 0, "count should be non-negative");
+            }
+            Err(ApiError::Parse(msg)) if msg.contains("No organization") => {
+                eprintln!("Skipping: no PULUMI_ORG configured");
+            }
+            Err(e) => panic!("unexpected error counting resources: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
     async fn integration_list_organizations() {
         let Some(client) = integration_client() else {
             eprintln!("Skipping integration test: no PULUMI_ACCESS_TOKEN");

--- a/src/api/client_platform.rs
+++ b/src/api/client_platform.rs
@@ -2,8 +2,7 @@
 
 use super::client::{map_gen_err, strip_frontmatter, ApiError, PulumiClient};
 use super::domain::{
-    RegistryPackage, RegistryTemplate, Resource, ResourceSummaryPoint, Service, TemplateRuntime,
-    User,
+    RegistryPackage, RegistryTemplate, ResourceSummaryPoint, Service, TemplateRuntime, User,
 };
 
 impl PulumiClient {
@@ -11,53 +10,25 @@ impl PulumiClient {
     // Resource Search API (via generated client)
     // ─────────────────────────────────────────────────────────────
 
-    /// Search resources (with pagination)
-    pub async fn search_resources(
-        &self,
-        org: Option<&str>,
-        query: &str,
-    ) -> Result<Vec<Resource>, ApiError> {
+    /// Total number of resources in the organization.
+    ///
+    /// Uses the search endpoint's `total` field with a single 1-item page,
+    /// so the count is exact and cheap even for orgs with 100k+ resources.
+    pub async fn count_resources(&self, org: Option<&str>) -> Result<i64, ApiError> {
         let org = self.org_or_default(org)?;
 
-        let mut all_resources = Vec::new();
-        let mut page: i64 = 1;
-        let page_size: i64 = 100;
+        let resp = self
+            .gen
+            .get_org_resource_search_v2_query()
+            .org_name(org)
+            .query("")
+            .page(1)
+            .size(1)
+            .send()
+            .await
+            .map_err(map_gen_err)?;
 
-        loop {
-            let resp = self
-                .gen
-                .get_org_resource_search_v2_query()
-                .org_name(org)
-                .query(query)
-                .page(page)
-                .size(page_size)
-                .send()
-                .await
-                .map_err(map_gen_err)?;
-
-            let data = resp.into_inner();
-            let fetched_count = data.resources.len();
-            let resources: Vec<Resource> = data.resources.into_iter().map(Into::into).collect();
-            all_resources.extend(resources);
-
-            let has_next = data
-                .pagination
-                .as_ref()
-                .and_then(|p| p.next.as_ref())
-                .is_some();
-
-            if !has_next || fetched_count < page_size as usize {
-                break;
-            }
-
-            page += 1;
-
-            if page > 100 {
-                break;
-            }
-        }
-
-        Ok(all_resources)
+        Ok(resp.into_inner().total.unwrap_or(0))
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/src/api/client_stacks.rs
+++ b/src/api/client_stacks.rs
@@ -8,20 +8,34 @@ impl PulumiClient {
     // Stacks API (via generated client)
     // ─────────────────────────────────────────────────────────────
 
-    /// List all stacks
+    /// List all stacks, following pagination (the API returns at most 1000 per call)
     pub async fn list_stacks(&self, org: Option<&str>) -> Result<Vec<Stack>, ApiError> {
         let org = self.org_or_default(org)?;
 
-        let resp = self
-            .gen
-            .list_user_stacks()
-            .organization(org)
-            .send()
-            .await
-            .map_err(map_gen_err)?;
+        let mut all: Vec<Stack> = Vec::new();
+        let mut token: Option<String> = None;
 
-        let data = resp.into_inner();
-        Ok(data.stacks.into_iter().map(Into::into).collect())
+        loop {
+            let mut req = self
+                .gen
+                .list_user_stacks()
+                .organization(org)
+                .max_results(1000);
+            if let Some(ref t) = token {
+                req = req.continuation_token(t);
+            }
+
+            let data = req.send().await.map_err(map_gen_err)?.into_inner();
+            all.extend(data.stacks.into_iter().map(Into::<Stack>::into));
+
+            token = data.continuation_token.filter(|t| !t.is_empty());
+            // ponytail: 100k cap guards against a runaway continuation loop
+            if token.is_none() || all.len() >= 100_000 {
+                break;
+            }
+        }
+
+        Ok(all)
     }
 
     /// Get stack details

--- a/src/api/convert.rs
+++ b/src/api/convert.rs
@@ -112,20 +112,6 @@ impl From<gen::AgentSlashCommand> for domain::NeoSlashCommand {
 // Resource conversions
 // ─────────────────────────────────────────────────────────────
 
-impl From<gen::ResourceResult> for domain::Resource {
-    fn from(r: gen::ResourceResult) -> Self {
-        Self {
-            resource_type: r.type_.unwrap_or_default(),
-            name: r.name.unwrap_or_default(),
-            id: r.id,
-            stack: r.stack,
-            project: r.project,
-            package: Some(r.package),
-            modified: r.modified,
-        }
-    }
-}
-
 impl From<gen::ResourceCountSummary> for domain::ResourceSummaryPoint {
     fn from(r: gen::ResourceCountSummary) -> Self {
         Self {
@@ -639,68 +625,6 @@ mod tests {
 
         let modified = neo_cmd.modified_at.expect("should have modified_at");
         assert!(modified.contains('T'), "should be RFC 3339: {modified}");
-    }
-
-    // ═════════════════════════════════════════════════════════════
-    // Resource conversion tests
-    // ═════════════════════════════════════════════════════════════
-
-    #[test]
-    fn resource_conversion_maps_all_fields() {
-        let gen_resource: gen::ResourceResult = gen::ResourceResult::builder()
-            .type_(Some("aws:s3:Bucket".to_string()))
-            .name(Some("my-bucket".to_string()))
-            .id(Some("bucket-123".to_string()))
-            .stack(Some("dev".to_string()))
-            .project(Some("my-project".to_string()))
-            .package("aws")
-            .module("s3")
-            .modified(Some("2024-01-15".to_string()))
-            .try_into()
-            .expect("valid ResourceResult");
-
-        let resource: domain::Resource = gen_resource.into();
-
-        assert_eq!(resource.resource_type, "aws:s3:Bucket");
-        assert_eq!(resource.name, "my-bucket");
-        assert_eq!(resource.id, Some("bucket-123".to_string()));
-        assert_eq!(resource.stack, Some("dev".to_string()));
-        assert_eq!(resource.project, Some("my-project".to_string()));
-        assert_eq!(resource.package, Some("aws".to_string()));
-        assert_eq!(resource.modified, Some("2024-01-15".to_string()));
-    }
-
-    #[test]
-    fn resource_conversion_none_type_defaults_to_empty() {
-        let gen_resource: gen::ResourceResult = gen::ResourceResult::builder()
-            .package("pkg")
-            .module("mod")
-            .try_into()
-            .expect("valid ResourceResult");
-
-        let resource: domain::Resource = gen_resource.into();
-
-        assert_eq!(
-            resource.resource_type, "",
-            "None type_ should default to empty string"
-        );
-        assert_eq!(
-            resource.name, "",
-            "None name should default to empty string"
-        );
-    }
-
-    #[test]
-    fn resource_conversion_package_always_wrapped_in_some() {
-        let gen_resource: gen::ResourceResult = gen::ResourceResult::builder()
-            .package("pulumi")
-            .module("mod")
-            .try_into()
-            .expect("valid ResourceResult");
-
-        let resource: domain::Resource = gen_resource.into();
-
-        assert_eq!(resource.package, Some("pulumi".to_string()));
     }
 
     // ═════════════════════════════════════════════════════════════

--- a/src/api/domain.rs
+++ b/src/api/domain.rs
@@ -478,25 +478,6 @@ pub struct NeoSlashCommandPayload {
     pub tag: String,
 }
 
-/// Pulumi Resource
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Resource {
-    #[serde(rename = "type")]
-    pub resource_type: String,
-    pub name: String,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub stack: Option<String>,
-    #[serde(default)]
-    pub project: Option<String>,
-    #[serde(default)]
-    pub package: Option<String>,
-    #[serde(default)]
-    pub modified: Option<String>,
-}
-
 /// Policy violation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,5 +18,5 @@ mod generated;
 pub use client::{ApiError, PulumiClient};
 pub use domain::{
     EscEnvironmentSummary, NeoMessage, NeoMessageType, NeoSlashCommand, NeoTask, OrgStackUpdate,
-    RegistryPackage, RegistryTemplate, Resource, ResourceSummaryPoint, Service, Stack,
+    RegistryPackage, RegistryTemplate, ResourceSummaryPoint, Service, Stack,
 };

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -92,6 +92,12 @@ impl App {
             self.is_loading = true;
             self.spinner.set_message("Loading data...");
 
+            // Mark dashboard tiles as loading until their data arrives
+            self.state.resource_count = None;
+            self.state.stacks_loading = true;
+            self.state.envs_loading = true;
+            self.state.neo_tasks_loading = true;
+
             // Spawn all data loads in parallel
             let client1 = client.clone();
             let org1 = org.clone();
@@ -141,9 +147,9 @@ impl App {
             let org4 = org.clone();
             let tx4 = tx.clone();
             tokio::spawn(async move {
-                match client4.search_resources(org4.as_deref(), "").await {
-                    Ok(resources) => {
-                        let _ = tx4.send(DataLoadResult::Resources(resources)).await;
+                match client4.count_resources(org4.as_deref()).await {
+                    Ok(count) => {
+                        let _ = tx4.send(DataLoadResult::ResourceCount(count)).await;
                     }
                     Err(e) => {
                         let _ = tx4
@@ -292,15 +298,18 @@ impl App {
 
             match result {
                 DataLoadResult::Stacks(stacks) => {
+                    self.state.stacks_loading = false;
                     self.state.stacks = stacks.clone();
                     self.stacks_list.set_items(stacks);
                 }
                 DataLoadResult::EscEnvironments(envs) => {
                     log::info!("Received {} ESC environments", envs.len());
+                    self.state.envs_loading = false;
                     self.state.esc_environments = envs.clone();
                     self.esc_list.set_items(envs);
                 }
                 DataLoadResult::NeoTasks(tasks) => {
+                    self.state.neo_tasks_loading = false;
                     let should_auto_load = !tasks.is_empty()
                         && self.state.current_task_id.is_none()
                         && self.state.neo_tasks.is_empty();
@@ -340,8 +349,8 @@ impl App {
                     log::info!("Received {} Neo slash commands", commands.len());
                     self.state.neo_slash_commands = commands;
                 }
-                DataLoadResult::Resources(resources) => {
-                    self.state.resources = resources;
+                DataLoadResult::ResourceCount(count) => {
+                    self.state.resource_count = Some(count);
                 }
                 DataLoadResult::Services(services) => {
                     log::info!("Received {} services", services.len());
@@ -399,6 +408,11 @@ impl App {
             // Clear loading state when all loads complete
             if self.pending_data_loads == 0 {
                 self.is_loading = false;
+                // Stop tile spinners even if a load errored out
+                self.state.stacks_loading = false;
+                self.state.envs_loading = false;
+                self.state.neo_tasks_loading = false;
+                self.state.resource_count.get_or_insert(0);
                 // Note: splash screen is now dismissed via user interaction, not auto-hide
             }
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -600,7 +600,7 @@ impl App {
             // Content based on current tab
             match tab {
                 Tab::Dashboard => {
-                    ui::render_dashboard(frame, theme, content_area, state);
+                    ui::render_dashboard(frame, theme, content_area, state, spinner_char);
                 }
                 Tab::Stacks => {
                     ui::render_stacks_view(

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -5,7 +5,7 @@
 
 use crate::api::{
     EscEnvironmentSummary, NeoMessage, NeoSlashCommand, NeoTask, OrgStackUpdate, RegistryPackage,
-    RegistryTemplate, Resource, ResourceSummaryPoint, Service, Stack,
+    RegistryTemplate, ResourceSummaryPoint, Service, Stack,
 };
 
 /// Async data loading result
@@ -15,7 +15,8 @@ pub enum DataLoadResult {
     EscEnvironments(Vec<EscEnvironmentSummary>),
     NeoTasks(Vec<NeoTask>),
     NeoSlashCommands(Vec<NeoSlashCommand>),
-    Resources(Vec<Resource>),
+    /// Total resource count for the dashboard tile
+    ResourceCount(i64),
     Services(Vec<Service>),
     PrivatePackages(Vec<RegistryPackage>),
     RegistryPackages(Vec<RegistryPackage>),
@@ -475,7 +476,12 @@ pub struct AppState {
     pub stacks: Vec<Stack>,
     pub esc_environments: Vec<EscEnvironmentSummary>,
     pub neo_tasks: Vec<NeoTask>,
-    pub resources: Vec<Resource>,
+    /// Total resource count (None while loading)
+    pub resource_count: Option<i64>,
+    /// Per-tile loading markers for the dashboard (set while a refresh is in flight)
+    pub stacks_loading: bool,
+    pub envs_loading: bool,
+    pub neo_tasks_loading: bool,
     /// Recent stack updates across the organization (for dashboard)
     pub recent_updates: Vec<OrgStackUpdate>,
     /// Resource count over time (for dashboard chart)

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -49,7 +49,13 @@ fn format_time_ago(timestamp: i64) -> String {
 }
 
 /// Render the dashboard view
-pub fn render_dashboard(frame: &mut Frame, theme: &Theme, area: Rect, state: &AppState) {
+pub fn render_dashboard(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    state: &AppState,
+    spinner_char: &str,
+) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -58,11 +64,17 @@ pub fn render_dashboard(frame: &mut Frame, theme: &Theme, area: Rect, state: &Ap
         ])
         .split(area);
 
-    render_stats_cards(frame, theme, chunks[0], state);
+    render_stats_cards(frame, theme, chunks[0], state, spinner_char);
     render_recent_activity(frame, theme, chunks[1], state);
 }
 
-fn render_stats_cards(frame: &mut Frame, theme: &Theme, area: Rect, state: &AppState) {
+fn render_stats_cards(
+    frame: &mut Frame,
+    theme: &Theme,
+    area: Rect,
+    state: &AppState,
+    spinner_char: &str,
+) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
@@ -74,60 +86,66 @@ fn render_stats_cards(frame: &mut Frame, theme: &Theme, area: Rect, state: &AppS
         .split(area);
 
     // Stacks card
-    let stacks_count = state.stacks.len();
+    let stacks_count = (!state.stacks_loading).then(|| state.stacks.len().to_string());
     render_stat_card(
         frame,
         theme,
         chunks[0],
         "Stacks",
-        &stacks_count.to_string(),
+        stacks_count.as_deref(),
+        spinner_char,
         symbols::DIAMOND,
         theme.primary,
     );
 
     // ESC Environments card
-    let env_count = state.esc_environments.len();
+    let env_count = (!state.envs_loading).then(|| state.esc_environments.len().to_string());
     render_stat_card(
         frame,
         theme,
         chunks[1],
         "Environments",
-        &env_count.to_string(),
+        env_count.as_deref(),
+        spinner_char,
         symbols::STAR,
         theme.secondary,
     );
 
     // Neo Tasks card
-    let neo_count = state.neo_tasks.len();
+    let neo_count = (!state.neo_tasks_loading).then(|| state.neo_tasks.len().to_string());
     render_stat_card(
         frame,
         theme,
         chunks[2],
         "Neo Tasks",
-        &neo_count.to_string(),
+        neo_count.as_deref(),
+        spinner_char,
         symbols::BULLET,
         theme.accent,
     );
 
     // Resources card
-    let resource_count = state.resources.len();
+    let resource_count = state.resource_count.map(|n| n.to_string());
     render_stat_card(
         frame,
         theme,
         chunks[3],
         "Resources",
-        &resource_count.to_string(),
+        resource_count.as_deref(),
+        spinner_char,
         symbols::CHECK,
         theme.success,
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_stat_card(
     frame: &mut Frame,
     theme: &Theme,
     area: Rect,
     title: &str,
-    value: &str,
+    value: Option<&str>,
+    spinner_char: &str,
     _icon: &str,
     accent_color: Color,
 ) {
@@ -139,6 +157,24 @@ fn render_stat_card(
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
+
+    // Still loading — show a spinner instead of a stale/empty number
+    let Some(value) = value else {
+        let vertical_padding = inner.height.saturating_sub(1) / 2;
+        let centered_area = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(vertical_padding),
+                Constraint::Length(1),
+                Constraint::Min(0),
+            ])
+            .split(inner)[1];
+        let paragraph = Paragraph::new(format!("{} loading...", spinner_char))
+            .style(theme.text_muted())
+            .alignment(Alignment::Center);
+        frame.render_widget(paragraph, centered_area);
+        return;
+    };
 
     // BigText with Quadrant pixel size is 4 rows tall
     let big_text_height = 4_u16;


### PR DESCRIPTION
## Problem (seen on the `pulumi` org)

- **Resources tile took ages and showed a wrong number**: `search_resources` fetched every resource 100 at a time (100 sequential requests ≈ 70s), then capped at 10,000 — while the org actually has **230,327** resources.
- **Stacks tile showed 1000**: `list_user_stacks` was called once without pagination; the server caps a page at 1000. The org actually has **10,460** stacks.
- **No loading indication in the tiles** while the data was in flight.

## Fix

- `count_resources()`: single `size=1` search query, read the response's `total` field — exact and ~0.4s regardless of org size. The fetch-everything `search_resources` (whose only consumer was this count) and the `Resource` domain type are deleted.
- `list_stacks()`: follows `continuationToken` with `maxResults=1000` (100k safety cap), fixing both the tile and the Stacks tab list.
- Dashboard tiles render an animated `⠋ loading...` while their datum hasn't arrived (per-tile loading flags reset on each refresh; flags also clear when all loads settle so an errored load can't spin forever).

## Verification

Live integration tests against the `pulumi` org (token from ESC `ediri/pulumi-idp/auth`), exercising the new code paths end-to-end:

```
integration_count_resources: 230327 resources ... ok
integration_list_stacks: got 10460 stacks ... ok   (11 pages)
integration_list_esc_environments: got 683 environments ... ok
test result: ok. 5 passed; 0 failed
```

Full suite: 79 passed / 0 failed (3 tests deleted with the unused `Resource` conversion), clippy `-D warnings` clean, fmt clean. Net **−35 lines**.

New `integration_count_resources` test covers the count path (skips without a token, like its siblings).

https://claude.ai/code/session_01Eq4ckheD9gvhNz6DkYbqJv